### PR TITLE
Add new modules storing models for individual bursts

### DIFF
--- a/diffstarpop/tests/test_tophat_burst.py
+++ b/diffstarpop/tests/test_tophat_burst.py
@@ -1,0 +1,33 @@
+"""
+"""
+from ..tophat_burst import _tophat_burst_sfh, _tophat_burst_smh
+from ..tophat_burst import DT_BURST
+
+EPSILON = 0.1
+
+
+def test_tophat_burst_sfh():
+    tburst_yr = 500_000
+    t0 = tburst_yr - DT_BURST
+    thalf = t0 + DT_BURST / 2
+    sfr_burst = 1.0
+    assert _tophat_burst_sfh(t0 - EPSILON, tburst_yr, sfr_burst) == 0.0
+    assert _tophat_burst_sfh(t0, tburst_yr, sfr_burst) == sfr_burst
+    assert _tophat_burst_sfh(t0 + EPSILON, tburst_yr, sfr_burst) == sfr_burst
+    assert _tophat_burst_sfh(thalf, tburst_yr, sfr_burst) == sfr_burst
+    assert _tophat_burst_sfh(tburst_yr - EPSILON, tburst_yr, sfr_burst) == sfr_burst
+    assert _tophat_burst_sfh(tburst_yr, tburst_yr, sfr_burst) == sfr_burst
+    assert _tophat_burst_sfh(tburst_yr + EPSILON, tburst_yr, sfr_burst) == 0.0
+
+
+def test_tophat_burst_smh():
+    tburst_yr = 500_000
+    t0 = tburst_yr - DT_BURST
+    thalf = t0 + DT_BURST / 2
+    sfr_burst = 1.0
+    mstar_burst = sfr_burst * DT_BURST
+    assert _tophat_burst_smh(t0 - EPSILON, tburst_yr, sfr_burst) == 0.0
+    assert _tophat_burst_smh(t0, tburst_yr, sfr_burst) == 0.0
+    assert _tophat_burst_smh(thalf, tburst_yr, sfr_burst) == mstar_burst / 2
+    assert _tophat_burst_smh(tburst_yr, tburst_yr, sfr_burst) == mstar_burst
+    assert _tophat_burst_smh(tburst_yr + EPSILON, tburst_yr, sfr_burst) == mstar_burst

--- a/diffstarpop/tests/test_triweight_burst.py
+++ b/diffstarpop/tests/test_triweight_burst.py
@@ -1,0 +1,89 @@
+"""
+"""
+import numpy as np
+from ..triweight_burst import _cuml_prob_age, _sfh_post_burst, _mstar_post_burst
+from ..triweight_burst import BURST_KERN_LGTLO, BURST_KERN_DLGT
+
+
+def test_sfh_post_burst_integrates_to_correct_final_mstar():
+    lgtarr = np.linspace(1, 11, 100)
+
+    for mstar_tot in (1e5, 1e9, 1e12):
+        cuml_mstar = []
+        for lgtmax in lgtarr:
+            lgtx = np.linspace(2, lgtmax, 500)
+            sfh = _sfh_post_burst(10 ** lgtx, mstar_tot)
+            result = np.trapz(sfh, x=10 ** lgtx)
+            cuml_mstar.append(result)
+        cuml_mstar = np.array(cuml_mstar)
+        assert np.allclose(cuml_mstar[-1], mstar_tot, rtol=0.1)
+        assert np.all(np.diff(cuml_mstar) / mstar_tot >= -0.1)
+
+
+def test_sfh_post_burst_integrates_to_mstar_post_burst():
+    lgtarr = np.linspace(1, 11, 200)
+
+    BURST_KERN_THI = BURST_KERN_LGTLO + BURST_KERN_DLGT
+    test_msk = (lgtarr > BURST_KERN_LGTLO + 0.1) & (lgtarr < BURST_KERN_THI - 0.1)
+
+    for mstar_tot in (1e5, 1e9, 1e12):
+        cuml_mstar = []
+        for lgtmax in lgtarr:
+            lgtx = np.linspace(2, lgtmax, 200)
+            sfh = _sfh_post_burst(10 ** lgtx, mstar_tot)
+            result = np.trapz(sfh, x=10 ** lgtx)
+            cuml_mstar.append(result)
+        cuml_mstar = np.array(cuml_mstar)
+        cuml_mstar2 = _mstar_post_burst(10 ** lgtarr, mstar_tot)
+        assert np.allclose(cuml_mstar[test_msk], cuml_mstar2[test_msk], rtol=0.05)
+
+
+def test_sfh_post_burst_has_correct_asymptotic_behavior():
+    lgtarr = np.linspace(1, 11, 100)
+    mstar_tot = 1e10
+    sfh = _sfh_post_burst(10 ** lgtarr, mstar_tot)
+
+    early_time_msk = lgtarr < BURST_KERN_LGTLO
+    assert np.allclose(sfh[early_time_msk], 0)
+
+    late_time_msk = lgtarr > (BURST_KERN_LGTLO + BURST_KERN_DLGT)
+    assert np.allclose(sfh[late_time_msk], 0, atol=0.0001)
+
+
+def test_mstar_post_burst_has_correct_asymptotic_behavior():
+    lgtarr = np.linspace(1, 11, 100)
+    for mstar_tot in (1e5, 1e9, 1e12):
+        smh = _mstar_post_burst(10 ** lgtarr, mstar_tot)
+
+        early_time_msk = lgtarr < BURST_KERN_LGTLO
+        assert np.allclose(smh[early_time_msk], 0, atol=0.001)
+
+        late_time_msk = lgtarr > BURST_KERN_LGTLO + BURST_KERN_DLGT
+        assert np.allclose(smh[late_time_msk], mstar_tot, rtol=0.01)
+
+
+def test_cuml_prob_lgage_is_properly_bounded():
+    lgtarr = np.linspace(1, 11, 100)
+    time_since_burst = 10 ** lgtarr
+    p = _cuml_prob_age(time_since_burst)
+    assert np.all(p >= 0)
+    assert np.all(p <= 1)
+
+
+def test_cuml_prob_lgage_has_correct_asymptotic_behavior():
+    lgtarr = np.linspace(1, 11, 100)
+    time_since_burst = 10 ** lgtarr
+    p = _cuml_prob_age(time_since_burst)
+
+    early_time_msk = lgtarr < BURST_KERN_LGTLO
+    assert np.allclose(p[early_time_msk], 0, atol=0.001)
+
+    late_time_msk = lgtarr > BURST_KERN_LGTLO + BURST_KERN_DLGT
+    assert np.allclose(p[late_time_msk], 1, atol=0.001)
+
+
+def test_cuml_prob_lgage_is_monotonic():
+    lgtarr = np.linspace(1, 11, 100)
+    time_since_burst = 10 ** lgtarr
+    p = _cuml_prob_age(time_since_burst)
+    assert np.all(np.diff(p) >= 0)

--- a/diffstarpop/tophat_burst.py
+++ b/diffstarpop/tophat_burst.py
@@ -1,0 +1,97 @@
+"""
+"""
+from jax import numpy as jnp
+from jax import jit as jjit
+
+
+DT_BURST = 10_000
+
+
+@jjit
+def _tophat_burst_sfh(t_yr, tburst_yr, sfr_burst, dt_burst=DT_BURST):
+    """Star formation history of a top-hat burst
+
+    Parameters
+    ----------
+    t_yr : ndarray of shape (n_times, )
+        Cosmic time in years
+
+    tburst_yr : float
+        Cosmic time the birst completes in years
+
+    sfr_burst : float
+        Constant value of SFR in Msun/yr during burst
+
+    dt_burst : float, optional
+        Duration of the burst
+        Default is set by BURST_DT at top of module
+        Should be much shorter than the shortest lifetime of the most massive star
+
+    Returns
+    -------
+    sfh : ndarray of shape (n_times, )
+        SFR in Msun/yr evaluated at the input times
+
+    """
+    t0 = tburst_yr - dt_burst
+    early_msk = t_yr >= t0
+    late_msk = t_yr <= tburst_yr
+    sfh = jnp.where(early_msk & late_msk, sfr_burst, 0.0)
+    return sfh
+
+
+@jjit
+def _tophat_burst_smh(t_yr, tburst_yr, sfr_burst, dt_burst=DT_BURST):
+    """Stellar mass history of a top-hat burst
+
+    Parameters
+    ----------
+    t_yr : ndarray of shape (n_times, )
+        Cosmic time in years
+
+    tburst_yr : float
+        Cosmic time the birst completes in years
+
+    sfr_burst : float
+        Constant value of SFR in Msun/yr during burst
+
+    dt_burst : float, optional
+        Duration of the burst
+        Default is set by BURST_DT at top of module
+        Should be much shorter than the shortest lifetime of the most massive star
+
+    Returns
+    -------
+    smh : ndarray of shape (n_times, )
+        Stellar mass in Msun evaluated at the input times
+
+    """
+    t0 = tburst_yr - dt_burst
+    early_msk = t_yr >= t0
+    late_msk = t_yr <= tburst_yr
+    dt = t_yr - t0
+    smh = jnp.where(early_msk & late_msk, sfr_burst * dt, 0.0)
+    smh = jnp.where(~late_msk, sfr_burst * dt_burst, smh)
+    return smh
+
+
+@jjit
+def _get_burst_sfr(delta_logsfr, logsfr_smooth):
+    """Get SFR of burst, defined in terms of delta_logsfr relative to smooth SFR
+
+    Parameters
+    ----------
+    delta_logsfr : float
+        Base-10 logarithmic difference between burst SFR and smooth SFR in Msun/yr
+
+    logsfr_smooth : float
+        Base-10 log of smooth SFR in Msun/yr at time of burst
+
+    Returns
+    -------
+    sfr_burst : float
+        Constant value of SFR in Msun/yr during burst
+    """
+    logsfr_burst = logsfr_smooth + delta_logsfr
+    sfr_burst = 10 ** logsfr_burst
+    return sfr_burst

--- a/diffstarpop/triweight_burst.py
+++ b/diffstarpop/triweight_burst.py
@@ -1,0 +1,61 @@
+"""
+"""
+from jax import numpy as jnp
+from jax import jit as jjit
+from jax import grad
+from jax import vmap
+
+
+BURST_KERN_LGTLO, BURST_KERN_DLGT = 4, 1
+C0 = 1 / 2
+C1 = 35 / 96
+C3 = -35 / 864
+C5 = 7 / 2592
+C7 = -5 / 69984
+BURST_TW_X0 = BURST_KERN_LGTLO + BURST_KERN_DLGT / 2
+BURST_TW_H = BURST_KERN_DLGT / 6
+
+
+@jjit
+def _tw_cuml_kern(x, m, h):
+    """Triweight kernel version of an err function."""
+    z = (x - m) / h
+    zz = z * z
+    zzz = zz * z
+    val = C0 + C1 * z + C3 * zzz + C5 * zzz * zz + C7 * zzz * zzz * z
+    val = jnp.where(z < -3, 0, val)
+    val = jnp.where(z > 3, 1, val)
+    return val
+
+
+@jjit
+def _tw_sigmoid(x, x0, tw_h, ymin, ymax):
+    height_diff = ymax - ymin
+    body = _tw_cuml_kern(x, x0, tw_h)
+    return ymin + height_diff * body
+
+
+@jjit
+def _cuml_prob_lgage(lgyr_since_burst):
+    return _tw_sigmoid(lgyr_since_burst, BURST_TW_X0, BURST_TW_H, 0, 1)
+
+
+@jjit
+def _cuml_prob_age(yr_since_burst):
+    return _cuml_prob_lgage(jnp.log10(yr_since_burst))
+
+
+_tw_burst_kern = jjit(vmap(grad(_cuml_prob_age), in_axes=0))
+
+
+@jjit
+def _sfh_post_burst(yr_since_burst, total_mstar_formed):
+    return _tw_burst_kern(yr_since_burst) * total_mstar_formed
+
+
+@jjit
+def _mstar_post_burst(yr_since_burst, total_mstar_formed):
+    lgt = jnp.log10(yr_since_burst)
+    norm = total_mstar_formed
+    res = _cuml_prob_lgage(lgt) * norm
+    return res


### PR DESCRIPTION
Models of individual bursts

The `tophat_burst.py` module implements a model for individual bursts that looks like this:
![tophat_burst_model](https://user-images.githubusercontent.com/6951595/173851548-0a806fa5-59a5-460d-a109-c42c8c6074aa.png)

The `triweight_burst.py` module implements a model for individual bursts that looks like this:
![triweight_burst_model](https://user-images.githubusercontent.com/6951595/173851578-1afd5e5f-280c-44da-9ae3-a0f89d1bcc89.png)

PR also includes tests enforcing reasonable behavior of both models.

cc @alexalar

