### PR TITLE
Add prototype model for burstiness

### DIFF
--- a/diffstarpop/diffburst.py
+++ b/diffstarpop/diffburst.py
@@ -1,0 +1,87 @@
+"""
+"""
+from jax import numpy as jnp
+from jax import jit as jjit
+from jax import vmap
+
+C0 = 1 / 2
+C1 = 35 / 96
+C3 = -35 / 864
+C5 = 7 / 2592
+C7 = -5 / 69984
+
+LGYR_STELLAR_AGE_MIN = 5.0
+DELTA_LGYR_STELLAR_AGES = 0.05
+LGYR_BURST_DURATION_MAX = 9.0
+DEFAULT_DBURST = 2.0
+
+
+@jjit
+def _tw_cuml_kern(x, m, h):
+    """Triweight kernel version of an err function."""
+    z = (x - m) / h
+    zz = z * z
+    zzz = zz * z
+    val = C0 + C1 * z + C3 * zzz + C5 * zzz * zz + C7 * zzz * zzz * z
+    val = jnp.where(z < -3, 0, val)
+    val = jnp.where(z > 3, 1, val)
+    return val
+
+
+@jjit
+def _tw_sigmoid(x, x0, tw_h, ymin, ymax):
+    height_diff = ymax - ymin
+    body = _tw_cuml_kern(x, x0, tw_h)
+    return ymin + height_diff * body
+
+
+@jjit
+def _burst_age_weights_kern(lgyr_since_burst, lgyr_burst_duration, lgyr_age_min):
+    delta = lgyr_burst_duration - lgyr_age_min
+    x0 = lgyr_age_min + delta / 2.0
+    tw_h = delta / 6.0
+    return _tw_sigmoid(lgyr_since_burst, x0, tw_h, 1.0, 0.0)
+
+
+@jjit
+def _get_lgyr_burst_duration(dburst, lgyr_age_min, delta_lgyr_ages, lgyr_burst_max):
+    lgyr_min = lgyr_age_min + delta_lgyr_ages
+    lgyr_max = lgyr_burst_max
+    dlgyr_tot = lgyr_max - lgyr_min
+    tw_h = dlgyr_tot / 6.0
+    x0 = (lgyr_max - lgyr_min) / 2.0
+    lgyr_burst_duration = _tw_sigmoid(dburst, x0, tw_h, lgyr_min, lgyr_max)
+    return lgyr_burst_duration
+
+
+@jjit
+def _burst_age_weights_cdf(
+    lgyr_since_burst,
+    dburst,
+    lgyr_age_min=LGYR_STELLAR_AGE_MIN,
+    delta_lgyr_ages=DELTA_LGYR_STELLAR_AGES,
+    lgyr_burst_max=LGYR_BURST_DURATION_MAX,
+):
+    lgyr_burst_duration = _get_lgyr_burst_duration(
+        dburst, lgyr_age_min, delta_lgyr_ages, lgyr_burst_max
+    )
+    return _burst_age_weights_kern(lgyr_since_burst, lgyr_burst_duration, lgyr_age_min)
+
+
+@jjit
+def _burst_age_weights(
+    lgyr_since_burst,
+    dburst,
+    lgyr_age_min=LGYR_STELLAR_AGE_MIN,
+    delta_lgyr_ages=DELTA_LGYR_STELLAR_AGES,
+    lgyr_burst_max=LGYR_BURST_DURATION_MAX,
+):
+    cdf = _burst_age_weights_cdf(
+        lgyr_since_burst, dburst, lgyr_age_min, delta_lgyr_ages, lgyr_burst_max
+    )
+    weights = cdf / jnp.sum(cdf)
+    return weights
+
+
+_A = (None, 0)
+_burst_age_weights_pop = jjit(vmap(_burst_age_weights, in_axes=_A))

--- a/diffstarpop/sfhpop.py
+++ b/diffstarpop/sfhpop.py
@@ -1,0 +1,191 @@
+"""
+"""
+import numpy as np
+from collections import OrderedDict
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import random as jran
+from jax import vmap
+from functools import partial
+from .pdf_mainseq import _get_mean_smah_params_mainseq
+from .pdf_mainseq import _get_cov_params_mainseq
+from .pdf_mainseq import _get_cov_scalar
+from diffstar.stars import DEFAULT_SFR_PARAMS as DEFAULT_SFR_PARAMS_DICT
+from diffstar.stars import _get_unbounded_sfr_params
+from diffstar.quenching import DEFAULT_Q_PARAMS as DEFAULT_Q_PARAMS_DICT
+from diffstar.quenching import _get_unbounded_q_params
+from diffstar.main_sequence import get_ms_sfh_from_mah_kern
+from diffstar.utils import _jax_get_dt_array
+from dsps.stellar_ages import _get_age_weights_from_tables
+from dsps.stellar_ages import _get_lg_age_bin_edges, _get_lgt_birth
+from .diffburst import _burst_age_weights_pop
+
+
+get_ms_sfh_scan_tobs_lgm0 = get_ms_sfh_from_mah_kern(
+    tobs_loop="scan", galpop_loop="vmap"
+)
+
+DEFAULT_UNBOUND_SFR_PARAMS = _get_unbounded_sfr_params(
+    *tuple(DEFAULT_SFR_PARAMS_DICT.values())
+)
+DEFAULT_UNBOUND_SFR_PARAMS_DICT = OrderedDict(
+    zip(DEFAULT_SFR_PARAMS_DICT.keys(), DEFAULT_UNBOUND_SFR_PARAMS)
+)
+DEFAULT_UNBOUND_Q_PARAMS = np.array(
+    _get_unbounded_q_params(*tuple(DEFAULT_Q_PARAMS_DICT.values()))
+)
+UH = DEFAULT_UNBOUND_SFR_PARAMS_DICT["indx_hi"]
+
+DEFAULT_UNBOUND_Q_PARAMS_MAIN_SEQ = DEFAULT_UNBOUND_Q_PARAMS.copy()
+DEFAULT_UNBOUND_Q_PARAMS_MAIN_SEQ[0] = 1.9
+
+
+SFR_MIN = 1e-12
+
+
+@jjit
+def _integrate_sfr(sfr, dt):
+    """Calculate the cumulative stellar mass history."""
+    return jnp.cumsum(sfr * dt) * 1e9
+
+
+_integrate_sfrpop = jjit(vmap(_integrate_sfr, in_axes=[0, None]))
+
+_A = [None, None, 0]
+_get_age_weights_from_tables_pop = jjit(vmap(_get_age_weights_from_tables, in_axes=_A))
+
+
+@jjit
+def _get_stellar_age_distributions(log_age_gyr, tarr_gyr, tobs_gyr, logsmh_pop):
+    log_age_gyr_bin_edges = _get_lg_age_bin_edges(log_age_gyr)
+    log_obs_gyr_bin_edges = _get_lgt_birth(tobs_gyr, log_age_gyr_bin_edges)
+
+    lgtarr_gyr = jnp.log10(tarr_gyr)
+    age_distributions = _get_age_weights_from_tables_pop(
+        log_obs_gyr_bin_edges, lgtarr_gyr, logsmh_pop
+    )
+    return age_distributions
+
+
+@jjit
+def _get_cov_scalar2(cov_params):
+    return _get_cov_scalar(*cov_params)
+
+
+_get_cov_vmap = jjit(vmap(_get_cov_scalar2))
+
+
+@jjit
+def _ms_means_and_covs_lgm0(lgm0):
+    means_ms = jnp.array(_get_mean_smah_params_mainseq(lgm0))
+
+    cov_params_ms = _get_cov_params_mainseq(lgm0)
+    cov_ms = _get_cov_scalar(*cov_params_ms)
+
+    return means_ms, cov_ms
+
+
+@jjit
+def _ms_means_and_covs_lgmpop(lgmpop):
+    means_ms_pop = jnp.array(_get_mean_smah_params_mainseq(lgmpop)).T
+
+    cov_params_ms = _get_cov_params_mainseq(lgmpop)
+    cov_ms = _get_cov_vmap(cov_params_ms)
+
+    return means_ms_pop, cov_ms
+
+
+@partial(jjit, static_argnames=["n_gals"])
+def _mc_ms_u_params_lgm0(ran_key, means_ms, cov_ms, n_gals):
+    ms_params = jran.multivariate_normal(ran_key, means_ms, cov_ms, shape=(n_gals,))
+    ulgm = ms_params[:, 0]
+    ulgy = ms_params[:, 1]
+    ul = ms_params[:, 2]
+    utau = ms_params[:, 3]
+
+    zz = jnp.zeros(n_gals)
+    uh = jnp.zeros(n_gals) + UH
+
+    ms_u_params = jnp.array((ulgm, ulgy, ul, uh, utau)).T
+    q_u_params = jnp.array([zz + p for p in DEFAULT_UNBOUND_Q_PARAMS_MAIN_SEQ]).T
+
+    return ms_u_params, q_u_params
+
+
+@jjit
+def _mc_ms_u_params_lgmpop(ran_key, means_ms_pop, cov_ms_pop):
+    ms_params = jran.multivariate_normal(ran_key, means_ms_pop, cov_ms_pop)
+    ulgm = ms_params[:, 0]
+    ulgy = ms_params[:, 1]
+    ul = ms_params[:, 2]
+    utau = ms_params[:, 3]
+
+    zz = 0.0 * ulgm
+    uh = zz + UH
+
+    ms_u_params = jnp.array((ulgm, ulgy, ul, uh, utau)).T
+    q_u_params = jnp.array([zz + p for p in DEFAULT_UNBOUND_Q_PARAMS_MAIN_SEQ]).T
+
+    return ms_u_params, q_u_params
+
+
+@partial(jjit, static_argnames=["n_gals"])
+def mc_galhalo_ms_lgm0(ran_key, mah_params_pop, tarr, n_gals):
+    lgm0 = mah_params_pop[0, 0]
+    means_ms, cov_ms = _ms_means_and_covs_lgm0(lgm0)
+
+    _res = _mc_ms_u_params_lgm0(ran_key, means_ms, cov_ms, n_gals)
+    ms_u_params_pop, q_u_params_pop = _res
+
+    ms_sfh_pop = get_ms_sfh_scan_tobs_lgm0(tarr, mah_params_pop, ms_u_params_pop)
+    ms_sfh_pop = jnp.where(ms_sfh_pop < SFR_MIN, SFR_MIN, ms_sfh_pop)
+
+    dtarr = _jax_get_dt_array(tarr)
+    ms_smh_pop = _integrate_sfrpop(ms_sfh_pop, dtarr)
+    ms_logsmh_pop = jnp.log10(ms_smh_pop)
+
+    return ms_u_params_pop, q_u_params_pop, ms_sfh_pop, ms_logsmh_pop
+
+
+@jjit
+def mc_galhalo_ms_lgmpop(ran_key, mah_params_pop, tarr):
+    lgmpop = mah_params_pop[:, 0]
+    means_ms_pop, cov_ms_pop = _ms_means_and_covs_lgmpop(lgmpop)
+
+    _res = _mc_ms_u_params_lgmpop(ran_key, means_ms_pop, cov_ms_pop)
+    ms_u_params_pop, q_u_params_pop = _res
+
+    ms_sfh_pop = get_ms_sfh_scan_tobs_lgm0(tarr, mah_params_pop, ms_u_params_pop)
+    ms_sfh_pop = jnp.where(ms_sfh_pop < SFR_MIN, SFR_MIN, ms_sfh_pop)
+
+    dtarr = _jax_get_dt_array(tarr)
+    ms_smh_pop = _integrate_sfrpop(ms_sfh_pop, dtarr)
+    ms_logsmh_pop = jnp.log10(ms_smh_pop)
+
+    return ms_u_params_pop, q_u_params_pop, ms_sfh_pop, ms_logsmh_pop
+
+
+@jjit
+def mc_age_weights_ms_lgmpop(ran_key, mah_params_pop, tarr_gyr, log_age_gyr, tobs_gyr):
+    _res = mc_galhalo_ms_lgmpop(ran_key, mah_params_pop, tarr_gyr)
+    ms_u_params_pop, q_u_params_pop, ms_sfh_pop, ms_logsmh_pop = _res
+
+    age_pdfs_pop = _get_stellar_age_distributions(
+        log_age_gyr, tarr_gyr, tobs_gyr, ms_logsmh_pop
+    )
+    return ms_u_params_pop, q_u_params_pop, ms_sfh_pop, ms_logsmh_pop, age_pdfs_pop
+
+
+@partial(jjit, static_argnames=["n_gals"])
+def mc_age_weights_burstpop_lgm0(ran_key, burstpop_params, n_gals, log_age_gyr):
+    lgfburst_min, lgfburst_max, dburst_min, dburst_max = burstpop_params
+    lgf_key, dburst_key = jran.split(ran_key, 2)
+    fburst_pop = 10 ** jran.uniform(
+        lgf_key, minval=lgfburst_min, maxval=lgfburst_max, shape=(n_gals,)
+    )
+    dburst_pop = jran.uniform(
+        dburst_key, minval=dburst_min, maxval=dburst_max, shape=(n_gals,)
+    )
+    log_age_yr = log_age_gyr + 9.0
+    burst_age_pdf_pop = _burst_age_weights_pop(log_age_yr, dburst_pop)
+    return fburst_pop, dburst_pop, burst_age_pdf_pop

--- a/diffstarpop/tests/test_diffburst.py
+++ b/diffstarpop/tests/test_diffburst.py
@@ -1,0 +1,42 @@
+"""
+"""
+import numpy as np
+from .. import diffburst as db
+
+
+def test_burst_age_weights_cdf_is_monotonic():
+    log_age_yr = np.linspace(-500, 500, 1000)
+    dburst_arr = np.linspace(-100, 100, 50)
+    for dburst in dburst_arr:
+        res = db._burst_age_weights_cdf(log_age_yr, dburst)
+        assert np.all(np.diff(res) <= 0)
+
+
+def test_burst_age_weights_cdf_is_correctly_bounded():
+    dburst_arr = np.linspace(-100, 100, 50)
+    for dburst in dburst_arr:
+        log_age_yr = np.linspace(-500, 500, 1000)
+        res = db._burst_age_weights_cdf(log_age_yr, dburst)
+        assert np.all(res >= 0)
+        assert np.all(res <= 1)
+
+        log_age_yr = db.LGYR_STELLAR_AGE_MIN
+        res = db._burst_age_weights(log_age_yr, dburst)
+        assert np.allclose(res, 1.0, atol=1e-3)
+
+
+def test_burst_age_weights_cdf_never_vanishes_everywhere():
+    log_age_yr = np.linspace(-500, 500, 1000)
+    dburst_arr = np.linspace(-100, 100, 50)
+    for dburst in dburst_arr:
+        log_age_yr = np.linspace(-500, 500, 1000)
+        res = db._burst_age_weights_cdf(log_age_yr, dburst)
+        assert np.any(res > 0)
+
+
+def test_burst_age_weights_sum_to_unity():
+    log_age_yr = np.linspace(-500, 500, 1000)
+    dburst_arr = np.linspace(-100, 100, 50)
+    for dburst in dburst_arr:
+        res = db._burst_age_weights(log_age_yr, dburst)
+        assert np.allclose(np.sum(res), 1.0)


### PR DESCRIPTION
New modules diffburst.py and sfhpop.py implement a burstiness model based on a one-parameter family of stellar-age PDF at z_obs. At z_obs, the stellar-age PDF is a weighted sum of:
1. the age distribution calculated from Diffstar SFH, and 
2. the directly-parametrized age PDF of the burst.

@alexalar This should be harmless to merge with your latest commit on the smoothpop branch. These are the modules I used to make [these recent plots](https://docs.google.com/presentation/d/1OJ9YynV_LvuyMKgEjmAs1kE3gAbIL95mjct6bIWTZXw/edit?usp=sharing).