### PR TITLE
Add diffburstpop.py module for computing age weights with burstiness

### DIFF
--- a/diffstarpop/diffburstpop.py
+++ b/diffstarpop/diffburstpop.py
@@ -1,0 +1,26 @@
+"""
+"""
+from jax import jit as jjit
+from jax import vmap
+from dsps.stellar_ages import _get_age_weights_from_tables, _get_lg_age_bin_edges
+from .diffburst import _burst_age_weights_pop
+
+
+_A = (None, None, 0)
+_get_age_weights_from_tables_pop = jjit(vmap(_get_age_weights_from_tables, in_axes=_A))
+
+
+@jjit
+def _get_bursty_age_weights(
+    lgt_ages, lgt_table, logsm_tables, dburst_pop, lgfburst_pop
+):
+    lgt_birth_bin_edges = _get_lg_age_bin_edges(lgt_ages)
+    age_weights_smooth = _get_age_weights_from_tables_pop(
+        lgt_birth_bin_edges, lgt_table, logsm_tables
+    )
+    age_weights_burst = _burst_age_weights_pop(lgt_ages, dburst_pop)
+
+    fburst_pop = 10 ** lgfburst_pop.reshape((-1, 1))
+    age_weights = fburst_pop * age_weights_burst + (1 - fburst_pop) * age_weights_smooth
+
+    return age_weights, age_weights_smooth, age_weights_burst

--- a/diffstarpop/tests/test_diffburstpop.py
+++ b/diffstarpop/tests/test_diffburstpop.py
@@ -1,0 +1,49 @@
+"""
+"""
+import numpy as np
+from jax import numpy as jnp
+from jax import random as jran
+from diffmah.monte_carlo_halo_population import mc_halo_population
+from ..diffburstpop import _get_bursty_age_weights
+from .. import sfhpop
+
+
+def test_get_bursty_age_weights():
+    T_MIN = 0.1
+    T0 = 13.8
+    N_T = 100
+
+    n_gals = 50
+    zz = np.zeros(n_gals)
+
+    tarr_gyr = np.linspace(T_MIN, T0, N_T)
+    lgtarr_gyr = np.log10(tarr_gyr)
+
+    logm0 = 12.0
+
+    halopop = mc_halo_population(tarr_gyr, T0, logm0 + zz)
+    mah_params_pop = (logm0 + zz, halopop.lgtc, halopop.early_index, halopop.late_index)
+    mah_params_pop = jnp.array(mah_params_pop).T
+
+    log_age_gyr = np.arange(-4, 1.35, 0.05)
+    n_ages = log_age_gyr.size
+
+    ran_key = jran.PRNGKey(0)
+    ms_key, ran_key = jran.split(ran_key, 2)
+
+    _res = sfhpop.mc_age_weights_ms_lgmpop(
+        ms_key, mah_params_pop, tarr_gyr, log_age_gyr, T0
+    )
+    ms_u_params_pop, q_u_params_pop, ms_sfh_pop, ms_logsmh_pop, age_pdfs_mspop = _res
+
+    dburst_pop = np.random.uniform(2, 2.5, n_gals)
+    lgfburst_pop = np.random.uniform(-3, -2, n_gals)
+
+    _res = _get_bursty_age_weights(
+        log_age_gyr, lgtarr_gyr, ms_logsmh_pop, dburst_pop, lgfburst_pop
+    )
+    age_weights, age_weights_smooth, age_weights_burst = _res
+
+    assert age_weights.shape == (n_gals, n_ages)
+    assert np.allclose(np.sum(age_weights, axis=1), 1.0, rtol=1e-3)
+    assert np.all(np.isfinite(age_weights))


### PR DESCRIPTION
New diffburstpop.py module computes probability weights for the distribution of stellar ages in the presence of variable levels of burstiness