### PR TITLE
Satellite specific quenching for satellites

### DIFF
--- a/diffstarpop/kernels/defaults_tpeak_line_satfrac.py
+++ b/diffstarpop/kernels/defaults_tpeak_line_satfrac.py
@@ -1,0 +1,60 @@
+"""
+"""
+
+import typing
+from collections import namedtuple
+
+from jax import jit as jjit
+from jax import numpy as jnp
+
+from .satquenchpop_model import (
+    DEFAULT_SATQUENCHPOP_PARAMS,
+    get_bounded_satquenchpop_params,
+    get_unbounded_satquenchpop_params,
+)
+from .sfh_pdf_tpeak_line_satfrac import (
+    SFH_PDF_QUENCH_PARAMS,
+    get_bounded_sfh_pdf_params,
+    get_unbounded_sfh_pdf_params,
+)
+
+
+# Define a namedtuple container for the params of each component
+class DiffstarPopParams(typing.NamedTuple):
+    sfh_pdf_cens_params: jnp.array
+    satquench_params: jnp.array
+
+
+DEFAULT_DIFFSTARPOP_PARAMS = DiffstarPopParams(
+    SFH_PDF_QUENCH_PARAMS, DEFAULT_SATQUENCHPOP_PARAMS
+)
+
+_U_PNAMES = ["u_" + key for key in DEFAULT_DIFFSTARPOP_PARAMS._fields]
+DiffstarPopUParams = namedtuple("DiffstarPopUParams", _U_PNAMES)
+
+
+@jjit
+def get_bounded_diffstarpop_params(diffstarpop_u_params):
+    sfh_pdf_cens_params = get_bounded_sfh_pdf_params(
+        diffstarpop_u_params.u_sfh_pdf_cens_params
+    )
+    satquench_params = get_bounded_satquenchpop_params(
+        diffstarpop_u_params.u_satquench_params
+    )
+    return DiffstarPopParams(sfh_pdf_cens_params, satquench_params)
+
+
+@jjit
+def get_unbounded_diffstarpop_params(diffstarpop_params):
+    u_sfh_pdf_params = get_unbounded_sfh_pdf_params(
+        diffstarpop_params.sfh_pdf_cens_params
+    )
+    u_satquench_params = get_unbounded_satquenchpop_params(
+        diffstarpop_params.satquench_params
+    )
+    return DiffstarPopUParams(u_sfh_pdf_params, u_satquench_params)
+
+
+DEFAULT_DIFFSTARPOP_U_PARAMS = get_unbounded_diffstarpop_params(
+    DEFAULT_DIFFSTARPOP_PARAMS
+)

--- a/diffstarpop/kernels/diffstarpop_tpeak_line_satfrac.py
+++ b/diffstarpop/kernels/diffstarpop_tpeak_line_satfrac.py
@@ -1,0 +1,147 @@
+"""
+"""
+
+from diffstar import DiffstarUParams, MSUParams, QUParams
+from diffstar.defaults import DEFAULT_DIFFSTAR_U_PARAMS, DEFAULT_Q_U_PARAMS_UNQUENCHED
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import random as jran
+
+from .satquenchpop_model import get_qprob_sat
+from .sfh_pdf_tpeak_line_satfrac import _sfh_pdf_scalar_kernel
+
+
+@jjit
+def mc_diffstar_u_params_singlegal_kernel(
+    diffstarpop_params,
+    logmp0,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
+    ran_key,
+):
+    means_covs = _diffstarpop_means_covs(
+        diffstarpop_params, logmp0, lgmu_infall, logmhost_infall, gyr_since_infall
+    )
+
+    u_indx_hi = DEFAULT_DIFFSTAR_U_PARAMS.u_ms_params.u_indx_hi
+
+    frac_quench_cen, frac_quench_sat = means_covs[:2]
+    frac_quench = jnp.where(upid == -1, frac_quench_cen, frac_quench_sat)
+    mu = means_covs[2]
+    mu_ms_block = mu[:4]
+    mu_qseq_block = mu[4:]
+    cov_qseq_ms_block = means_covs[3]
+    cov_qseq_q_block = means_covs[4]
+
+    q_key_ms_block, q_key_q_block, frac_q_key = jran.split(ran_key, 3)
+
+    u_params_qseq_ms_block = jran.multivariate_normal(
+        q_key_ms_block, jnp.array(mu_ms_block), cov_qseq_ms_block, shape=()
+    )
+    u_params_qseq_q_block = jran.multivariate_normal(
+        q_key_q_block, jnp.array(mu_qseq_block), cov_qseq_q_block, shape=()
+    )
+    u_params_q = jnp.array(
+        (
+            *u_params_qseq_ms_block[:3],
+            u_indx_hi,
+            u_params_qseq_ms_block[3],
+            *u_params_qseq_q_block,
+        )
+    )
+    u_params_q = DiffstarUParams(MSUParams(*u_params_q[:5]), QUParams(*u_params_q[5:]))
+
+    u_params_ms = jnp.array(
+        (
+            *u_params_qseq_ms_block[:3],
+            u_indx_hi,
+            u_params_qseq_ms_block[3],
+            *DEFAULT_Q_U_PARAMS_UNQUENCHED,
+        )
+    )
+    u_params_ms = DiffstarUParams(
+        MSUParams(*u_params_ms[:5]), QUParams(*u_params_ms[5:])
+    )
+
+    uran = jran.uniform(frac_q_key, minval=0, maxval=1, shape=())
+    mc_is_quenched_sequence = uran < frac_quench
+
+    return u_params_ms, u_params_q, frac_quench, mc_is_quenched_sequence
+
+
+@jjit
+def _diffstarpop_means_covs(
+    diffstarpop_params, logmp0, lgmu_infall, logmhost_infall, gyr_since_infall
+):
+    means_covs = _sfh_pdf_scalar_kernel(diffstarpop_params.sfh_pdf_cens_params, logmp0)
+
+    # Modify frac_q for satellites
+    frac_q = means_covs[0]
+    frac_q = get_qprob_sat(
+        diffstarpop_params.satquench_params,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        frac_q,
+    )
+    means_covs = (frac_q, *means_covs[1:])
+    return means_covs
+
+
+@jjit
+def _diffstarpop_means_covs_cen(diffstarpop_params, logmp0):
+    means_covs = _sfh_pdf_scalar_kernel(diffstarpop_params.sfh_pdf_cens_params, logmp0)
+
+    return means_covs
+
+
+@jjit
+def mc_diffstar_u_params_singlegal_kernel_cen(diffstarpop_params, logmp0, ran_key):
+    means_covs = _diffstarpop_means_covs_cen(diffstarpop_params, logmp0)
+
+    u_indx_hi = DEFAULT_DIFFSTAR_U_PARAMS.u_ms_params.u_indx_hi
+
+    frac_quench_cen, frac_quench_sat = means_covs[:2]
+    frac_quench = frac_quench_cen
+    mu = means_covs[2]
+    mu_ms_block = mu[:4]
+    mu_qseq_block = mu[4:]
+    cov_qseq_ms_block = means_covs[3]
+    cov_qseq_q_block = means_covs[4]
+
+    q_key_ms_block, q_key_q_block, frac_q_key = jran.split(ran_key, 3)
+
+    u_params_qseq_ms_block = jran.multivariate_normal(
+        q_key_ms_block, jnp.array(mu_ms_block), cov_qseq_ms_block, shape=()
+    )
+    u_params_qseq_q_block = jran.multivariate_normal(
+        q_key_q_block, jnp.array(mu_qseq_block), cov_qseq_q_block, shape=()
+    )
+    u_params_q = jnp.array(
+        (
+            *u_params_qseq_ms_block[:3],
+            u_indx_hi,
+            u_params_qseq_ms_block[3],
+            *u_params_qseq_q_block,
+        )
+    )
+    u_params_q = DiffstarUParams(MSUParams(*u_params_q[:5]), QUParams(*u_params_q[5:]))
+
+    u_params_ms = jnp.array(
+        (
+            *u_params_qseq_ms_block[:3],
+            u_indx_hi,
+            u_params_qseq_ms_block[3],
+            *DEFAULT_Q_U_PARAMS_UNQUENCHED,
+        )
+    )
+    u_params_ms = DiffstarUParams(
+        MSUParams(*u_params_ms[:5]), QUParams(*u_params_ms[5:])
+    )
+
+    uran = jran.uniform(frac_q_key, minval=0, maxval=1, shape=())
+    mc_is_quenched_sequence = uran < frac_quench
+
+    return u_params_ms, u_params_q, frac_quench, mc_is_quenched_sequence

--- a/diffstarpop/kernels/sfh_pdf_tpeak_line_satfrac.py
+++ b/diffstarpop/kernels/sfh_pdf_tpeak_line_satfrac.py
@@ -1,0 +1,577 @@
+"""Model of a quenched galaxy population calibrated to SMDPL halos."""
+
+from collections import OrderedDict, namedtuple
+
+from diffmah.utils import get_cholesky_from_params
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import vmap
+
+from ..utils import (
+    _inverse_sigmoid,
+    _sigmoid,
+    covariance_from_correlation,
+    smoothly_clipped_line,
+)
+
+
+TODAY = 13.8
+LGT0 = jnp.log10(TODAY)
+
+LGM_X0 = 12.5
+LGM_K = 2.0
+LGMCRIT_K = 4.0
+BOUNDING_K = 0.1
+RHO_BOUNDS = (-0.3, 0.3)
+
+SFH_PDF_QUENCH_MU_PDICT = OrderedDict(
+    mean_ulgm_int=12.204,
+    mean_ulgm_slp=-0.022,
+    mean_ulgy_int=-0.118,
+    mean_ulgy_slp=-0.190,
+    mean_ul_int=-0.266,
+    mean_ul_slp=-0.190,
+    mean_utau_int=0.956,
+    mean_utau_slp=-8.489,
+    mean_uqt_int=0.941,
+    mean_uqt_slp=-0.369,
+    mean_uqs_int=-0.271,
+    mean_uqs_slp=0.367,
+    mean_udrop_int=-1.986,
+    mean_udrop_slp=-3.437,
+    mean_urej_int=-0.842,
+    mean_urej_slp=0.191,
+)
+SFH_PDF_QUENCH_MU_BOUNDS_PDICT = OrderedDict(
+    mean_ulgm_int=(11.0, 13.0),
+    mean_ulgm_slp=(-20.0, 20.0),
+    mean_ulgy_int=(-1.0, 3.5),
+    mean_ulgy_slp=(-20.0, 20.0),
+    mean_ul_int=(-3.0, 5.0),
+    mean_ul_slp=(-20.0, 20.0),
+    mean_utau_int=(-25.0, 50.0),
+    mean_utau_slp=(-20.0, 20.0),
+    mean_uqt_int=(0.0, 2.0),
+    mean_uqt_slp=(-20.0, 20.0),
+    mean_uqs_int=(-5.0, 2.0),
+    mean_uqs_slp=(-20.0, 20.0),
+    mean_udrop_int=(-3.0, 2.0),
+    mean_udrop_slp=(-20.0, 20.0),
+    mean_urej_int=(-10.0, 2.0),
+    mean_urej_slp=(-20.0, 20.0),
+)
+
+SFH_PDF_QUENCH_COV_MS_BLOCK_PDICT = OrderedDict(
+    std_ulgm_int=0.174,
+    std_ulgm_slp=0.049,
+    std_ulgy_int=0.414,
+    std_ulgy_slp=-0.118,
+    std_ul_int=0.381,
+    std_ul_slp=-0.162,
+    std_utau_int=5.033,
+    std_utau_slp=1.837,
+    rho_ulgy_ulgm_int=0.610,
+    rho_ulgy_ulgm_slp=-0.336,
+    rho_ul_ulgm_int=-1.247,
+    rho_ul_ulgm_slp=-0.445,
+    rho_ul_ulgy_int=0.795,
+    rho_ul_ulgy_slp=-0.082,
+    rho_utau_ulgm_int=-0.298,
+    rho_utau_ulgm_slp=0.915,
+    rho_utau_ulgy_int=2.161,
+    rho_utau_ulgy_slp=0.326,
+    rho_utau_ul_int=-0.480,
+    rho_utau_ul_slp=0.755,
+)
+SFH_PDF_QUENCH_COV_MS_BLOCK_BOUNDS_PDICT = OrderedDict(
+    std_ulgm_int=(0.01, 1.0),
+    std_ulgm_slp=(-1.00, 1.0),
+    std_ulgy_int=(0.01, 1.0),
+    std_ulgy_slp=(-1.00, 1.0),
+    std_ul_int=(0.01, 1.0),
+    std_ul_slp=(-1.00, 1.0),
+    std_utau_int=(1.00, 12.0),
+    std_utau_slp=(-3.00, 3.0),
+    rho_ulgy_ulgm_int=(-20.0, 20.0),
+    rho_ulgy_ulgm_slp=(-20.0, 20.0),
+    rho_ul_ulgm_int=(-20.0, 20.0),
+    rho_ul_ulgm_slp=(-20.0, 20.0),
+    rho_ul_ulgy_int=(-20.0, 20.0),
+    rho_ul_ulgy_slp=(-20.0, 20.0),
+    rho_utau_ulgm_int=(-20.0, 20.0),
+    rho_utau_ulgm_slp=(-20.0, 20.0),
+    rho_utau_ulgy_int=(-20.0, 20.0),
+    rho_utau_ulgy_slp=(-20.0, 20.0),
+    rho_utau_ul_int=(-20.0, 20.0),
+    rho_utau_ul_slp=(-20.0, 20.0),
+)
+
+SFH_PDF_QUENCH_COV_Q_BLOCK_PDICT = OrderedDict(
+    std_uqt_int=0.082,
+    std_uqt_slp=-0.049,
+    std_uqs_int=0.451,
+    std_uqs_slp=-0.097,
+    std_udrop_int=0.529,
+    std_udrop_slp=-0.191,
+    std_urej_int=1.332,
+    std_urej_slp=0.017,
+    rho_uqs_uqt_int=1.374,
+    rho_uqs_uqt_slp=0.103,
+    rho_udrop_uqt_int=2.630,
+    rho_udrop_uqt_slp=0.086,
+    rho_udrop_uqs_int=0.598,
+    rho_udrop_uqs_slp=0.153,
+    rho_urej_uqt_int=-1.040,
+    rho_urej_uqt_slp=-0.606,
+    rho_urej_uqs_int=3.002,
+    rho_urej_uqs_slp=0.076,
+    rho_urej_udrop_int=-0.437,
+    rho_urej_udrop_slp=0.509,
+)
+SFH_PDF_QUENCH_COV_Q_BLOCK_BOUNDS_PDICT = OrderedDict(
+    std_uqt_int=(0.01, 0.5),
+    std_uqt_slp=(-1.00, 1.0),
+    std_uqs_int=(0.01, 1.0),
+    std_uqs_slp=(-1.00, 1.0),
+    std_udrop_int=(0.01, 2.0),
+    std_udrop_slp=(-1.00, 1.0),
+    std_urej_int=(0.01, 2.0),
+    std_urej_slp=(-1.00, 1.0),
+    rho_uqs_uqt_int=(-20.0, 20.0),
+    rho_uqs_uqt_slp=(-20.0, 20.0),
+    rho_udrop_uqt_int=(-20.0, 20.0),
+    rho_udrop_uqt_slp=(-20.0, 20.0),
+    rho_udrop_uqs_int=(-20.0, 20.0),
+    rho_udrop_uqs_slp=(-20.0, 20.0),
+    rho_urej_uqt_int=(-20.0, 20.0),
+    rho_urej_uqt_slp=(-20.0, 20.0),
+    rho_urej_uqs_int=(-20.0, 20.0),
+    rho_urej_uqs_slp=(-20.0, 20.0),
+    rho_urej_udrop_int=(-20.0, 20.0),
+    rho_urej_udrop_slp=(-20.0, 20.0),
+)
+SFH_PDF_FRAC_QUENCH_PDICT = OrderedDict(
+    frac_quench_cen_x0=11.956,
+    frac_quench_cen_k=3.627,
+    frac_quench_cen_ylo=0.014,
+    frac_quench_cen_yhi=0.995,
+    frac_quench_sat_x0=11.956,
+    frac_quench_sat_k=3.627,
+    frac_quench_sat_ylo=0.014,
+    frac_quench_sat_yhi=0.995,
+)
+SFH_PDF_FRAC_QUENCH_BOUNDS_PDICT = OrderedDict(
+    frac_quench_cen_x0=(10.0, 13.0),
+    frac_quench_cen_k=(0.01, 5.0),
+    frac_quench_cen_ylo=(0.0, 0.5),
+    frac_quench_cen_yhi=(0.5, 1.0),
+    frac_quench_sat_x0=(10.0, 13.0),
+    frac_quench_sat_k=(0.01, 5.0),
+    frac_quench_sat_ylo=(0.0, 0.5),
+    frac_quench_sat_yhi=(0.5, 1.0),
+)
+
+BOUNDING_MEAN_VALS_PDICT = OrderedDict(
+    mean_ulgm=(11.0, 13.0),
+    mean_ulgy=(-1.0, 3.5),
+    mean_ul=(-3.0, 5.0),
+    mean_utau=(-25.0, 50.0),
+    mean_uqt=(0.0, 2.0),
+    mean_uqs=(-5.0, 2.0),
+    mean_udrop=(-3.0, 2.0),
+    mean_urej=(-10.0, 2.0),
+)
+
+BOUNDING_STD_VALS_PDICT = OrderedDict(
+    std_ulgm=(0.01, 1.0),
+    std_ulgy=(0.01, 1.0),
+    std_ul=(0.01, 1.0),
+    std_utau=(1.00, 12.0),
+    std_uqt=(0.01, 0.5),
+    std_uqs=(0.01, 1.0),
+    std_udrop=(0.01, 2.0),
+    std_urej=(0.01, 2.0),
+)
+
+BOUNDING_RHO_VALS_PDICT = OrderedDict(
+    rho_ulgy_ulgm=RHO_BOUNDS,
+    rho_ul_ulgm=RHO_BOUNDS,
+    rho_ul_ulgy=RHO_BOUNDS,
+    rho_utau_ulgm=RHO_BOUNDS,
+    rho_utau_ulgy=RHO_BOUNDS,
+    rho_utau_ul=RHO_BOUNDS,
+    rho_uqs_uqt=RHO_BOUNDS,
+    rho_udrop_uqt=RHO_BOUNDS,
+    rho_udrop_uqs=RHO_BOUNDS,
+    rho_urej_uqt=RHO_BOUNDS,
+    rho_urej_uqs=RHO_BOUNDS,
+    rho_urej_udrop=RHO_BOUNDS,
+)
+
+SFH_PDF_QUENCH_PDICT = SFH_PDF_FRAC_QUENCH_PDICT.copy()
+SFH_PDF_QUENCH_PDICT.update(SFH_PDF_QUENCH_MU_PDICT)
+SFH_PDF_QUENCH_PDICT.update(SFH_PDF_QUENCH_COV_MS_BLOCK_PDICT)
+SFH_PDF_QUENCH_PDICT.update(SFH_PDF_QUENCH_COV_Q_BLOCK_PDICT)
+
+SFH_PDF_QUENCH_BOUNDS_PDICT = SFH_PDF_FRAC_QUENCH_BOUNDS_PDICT.copy()
+SFH_PDF_QUENCH_BOUNDS_PDICT.update(SFH_PDF_QUENCH_MU_BOUNDS_PDICT)
+SFH_PDF_QUENCH_BOUNDS_PDICT.update(SFH_PDF_QUENCH_COV_MS_BLOCK_BOUNDS_PDICT)
+SFH_PDF_QUENCH_BOUNDS_PDICT.update(SFH_PDF_QUENCH_COV_Q_BLOCK_BOUNDS_PDICT)
+
+BOUNDING_VALS_PDICT = BOUNDING_MEAN_VALS_PDICT.copy()
+BOUNDING_VALS_PDICT.update(BOUNDING_STD_VALS_PDICT.copy())
+BOUNDING_VALS_PDICT.update(BOUNDING_RHO_VALS_PDICT.copy())
+
+QseqParams = namedtuple("QseqParams", list(SFH_PDF_QUENCH_PDICT.keys()))
+SFH_PDF_QUENCH_PARAMS = QseqParams(**SFH_PDF_QUENCH_PDICT)
+SFH_PDF_QUENCH_PBOUNDS = QseqParams(**SFH_PDF_QUENCH_BOUNDS_PDICT)
+
+_UPNAMES = ["u_" + key for key in QseqParams._fields]
+QseqUParams = namedtuple("QseqUParams", _UPNAMES)
+
+BoundingParams = namedtuple("BoundingParams", list(BOUNDING_VALS_PDICT.keys()))
+BOUNDING_VALS = BoundingParams(**BOUNDING_VALS_PDICT)
+
+
+def line_model(x, y0, m, y_lo, y_hi):
+    return smoothly_clipped_line(x, LGM_X0, y0, m, y_lo, y_hi)
+
+
+@jjit
+def _sfh_pdf_scalar_kernel(params, logmp0):
+    frac_quench_cen = _frac_quench_cen_vs_logmp0(params, logmp0)
+    frac_quench_sat = _frac_quench_sat_vs_logmp0(params, logmp0)
+
+    mu = _get_mean_u_params(params, logmp0)
+    cov_qseq_ms_block = _get_covariance_qseq_ms_block(params, logmp0)
+    cov_qseq_q_block = _get_covariance_qseq_q_block(params, logmp0)
+
+    return (
+        frac_quench_cen,
+        frac_quench_sat,
+        mu,
+        cov_qseq_ms_block,
+        cov_qseq_q_block,
+    )
+
+
+@jjit
+def _get_mean_u_params(params, logmp0):
+
+    ulgm = line_model(
+        logmp0,
+        params.mean_ulgm_int,
+        params.mean_ulgm_slp,
+        *BOUNDING_VALS.mean_ulgm,
+    )
+
+    ulgy = line_model(
+        logmp0,
+        params.mean_ulgy_int,
+        params.mean_ulgy_slp,
+        *BOUNDING_VALS.mean_ulgy,
+    )
+
+    ul = line_model(
+        logmp0,
+        params.mean_ul_int,
+        params.mean_ul_slp,
+        *BOUNDING_VALS.mean_ul,
+    )
+
+    utau = line_model(
+        logmp0,
+        params.mean_utau_int,
+        params.mean_utau_slp,
+        *BOUNDING_VALS.mean_utau,
+    )
+
+    uqt = line_model(
+        logmp0,
+        params.mean_uqt_int,
+        params.mean_uqt_slp,
+        *BOUNDING_VALS.mean_uqt,
+    )
+
+    uqs = line_model(
+        logmp0,
+        params.mean_uqs_int,
+        params.mean_uqs_slp,
+        *BOUNDING_VALS.mean_uqs,
+    )
+
+    udrop = line_model(
+        logmp0,
+        params.mean_udrop_int,
+        params.mean_udrop_slp,
+        *BOUNDING_VALS.mean_udrop,
+    )
+
+    urej = line_model(
+        logmp0,
+        params.mean_urej_int,
+        params.mean_urej_slp,
+        *BOUNDING_VALS.mean_urej,
+    )
+    return (ulgm, ulgy, ul, utau, uqt, uqs, udrop, urej)
+
+
+@jjit
+def _get_cov_params_qseq_ms_block(params, logmp0):
+
+    std_ulgm = line_model(
+        logmp0,
+        params.std_ulgm_int,
+        params.std_ulgm_slp,
+        *BOUNDING_VALS.std_ulgm,
+    )
+
+    std_ulgy = line_model(
+        logmp0,
+        params.std_ulgy_int,
+        params.std_ulgy_slp,
+        *BOUNDING_VALS.std_ulgy,
+    )
+
+    std_ul = line_model(
+        logmp0,
+        params.std_ul_int,
+        params.std_ul_slp,
+        *BOUNDING_VALS.std_ul,
+    )
+
+    std_utau = line_model(
+        logmp0,
+        params.std_utau_int,
+        params.std_utau_slp,
+        *BOUNDING_VALS.std_utau,
+    )
+
+    rho_ulgy_ulgm = line_model(
+        logmp0,
+        params.rho_ulgy_ulgm_int,
+        params.rho_ulgy_ulgm_slp,
+        *BOUNDING_VALS.rho_ulgy_ulgm,
+    )
+
+    rho_ul_ulgm = line_model(
+        logmp0,
+        params.rho_ul_ulgm_int,
+        params.rho_ul_ulgm_slp,
+        *BOUNDING_VALS.rho_ul_ulgm,
+    )
+
+    rho_ul_ulgy = line_model(
+        logmp0,
+        params.rho_ul_ulgy_int,
+        params.rho_ul_ulgy_slp,
+        *BOUNDING_VALS.rho_ul_ulgy,
+    )
+
+    rho_utau_ulgm = line_model(
+        logmp0,
+        params.rho_utau_ulgm_int,
+        params.rho_utau_ulgm_slp,
+        *BOUNDING_VALS.rho_utau_ulgm,
+    )
+
+    rho_utau_ulgy = line_model(
+        logmp0,
+        params.rho_utau_ulgy_int,
+        params.rho_utau_ulgy_slp,
+        *BOUNDING_VALS.rho_utau_ulgy,
+    )
+
+    rho_utau_ul = line_model(
+        logmp0,
+        params.rho_utau_ul_int,
+        params.rho_utau_ul_slp,
+        *BOUNDING_VALS.rho_utau_ul,
+    )
+
+    diags = std_ulgm, std_ulgy, std_ul, std_utau
+    off_diags = (
+        rho_ulgy_ulgm,
+        rho_ul_ulgm,
+        rho_ul_ulgy,
+        rho_utau_ulgm,
+        rho_utau_ulgy,
+        rho_utau_ul,
+    )
+    return diags, off_diags
+
+
+@jjit
+def _get_cov_params_qseq_q_block(params, logmp0):
+
+    std_uqt = line_model(
+        logmp0,
+        params.std_uqt_int,
+        params.std_uqt_slp,
+        *BOUNDING_VALS.std_uqt,
+    )
+
+    std_uqs = line_model(
+        logmp0,
+        params.std_uqs_int,
+        params.std_uqs_slp,
+        *BOUNDING_VALS.std_uqs,
+    )
+
+    std_udrop = line_model(
+        logmp0,
+        params.std_udrop_int,
+        params.std_udrop_slp,
+        *BOUNDING_VALS.std_udrop,
+    )
+
+    std_urej = line_model(
+        logmp0,
+        params.std_urej_int,
+        params.std_urej_slp,
+        *BOUNDING_VALS.std_urej,
+    )
+
+    rho_uqs_uqt = line_model(
+        logmp0,
+        params.rho_uqs_uqt_int,
+        params.rho_uqs_uqt_slp,
+        *BOUNDING_VALS.rho_uqs_uqt,
+    )
+
+    rho_udrop_uqt = line_model(
+        logmp0,
+        params.rho_udrop_uqt_int,
+        params.rho_udrop_uqt_slp,
+        *BOUNDING_VALS.rho_udrop_uqt,
+    )
+
+    rho_udrop_uqs = line_model(
+        logmp0,
+        params.rho_udrop_uqs_int,
+        params.rho_udrop_uqs_slp,
+        *BOUNDING_VALS.rho_udrop_uqs,
+    )
+
+    rho_urej_uqt = line_model(
+        logmp0,
+        params.rho_urej_uqt_int,
+        params.rho_urej_uqt_slp,
+        *BOUNDING_VALS.rho_urej_uqt,
+    )
+
+    rho_urej_uqs = line_model(
+        logmp0,
+        params.rho_urej_uqs_int,
+        params.rho_urej_uqs_slp,
+        *BOUNDING_VALS.rho_urej_uqs,
+    )
+
+    rho_urej_udrop = line_model(
+        logmp0,
+        params.rho_urej_udrop_int,
+        params.rho_urej_udrop_slp,
+        *BOUNDING_VALS.rho_urej_udrop,
+    )
+
+    diags = std_uqt, std_uqs, std_udrop, std_urej
+    off_diags = (
+        rho_uqs_uqt,
+        rho_udrop_uqt,
+        rho_udrop_uqs,
+        rho_urej_uqt,
+        rho_urej_uqs,
+        rho_urej_udrop,
+    )
+
+    return diags, off_diags
+
+
+@jjit
+def _get_covariance_qseq_q_block(params, logmp0):
+    diags, off_diags = _get_cov_params_qseq_q_block(params, logmp0)
+    ones = jnp.ones(len(diags))
+    x = jnp.array((*ones, *off_diags))
+    M = get_cholesky_from_params(x)
+    corr_matrix = jnp.where(M == 0, M.T, M)
+    cov_qseq_q_block = covariance_from_correlation(corr_matrix, jnp.array(diags))
+    return cov_qseq_q_block
+
+
+@jjit
+def _get_covariance_qseq_ms_block(params, logmp0):
+    diags, off_diags = _get_cov_params_qseq_ms_block(params, logmp0)
+    ones = jnp.ones(len(diags))
+    x = jnp.array((*ones, *off_diags))
+    M = get_cholesky_from_params(x)
+    corr_matrix = jnp.where(M == 0, M.T, M)
+    cov_qseq_ms_block = covariance_from_correlation(corr_matrix, jnp.array(diags))
+    return cov_qseq_ms_block
+
+
+@jjit
+def _frac_quench_cen_vs_logmp0(params, logmp0):
+    frac_q_cen = _sigmoid(
+        logmp0,
+        params.frac_quench_cen_x0,
+        params.frac_quench_cen_k,
+        params.frac_quench_cen_ylo,
+        params.frac_quench_cen_yhi,
+    )
+    return frac_q_cen
+
+
+@jjit
+def _frac_quench_sat_vs_logmp0(params, logmp0):
+    frac_q_sat = _sigmoid(
+        logmp0,
+        params.frac_quench_sat_x0,
+        params.frac_quench_sat_k,
+        params.frac_quench_sat_ylo,
+        params.frac_quench_sat_yhi,
+    )
+    return frac_q_sat
+
+
+@jjit
+def _get_p_from_u_p_scalar(u_p, bounds):
+    lo, hi = bounds
+    p0 = 0.5 * (lo + hi)
+    p = _sigmoid(u_p, p0, BOUNDING_K, lo, hi)
+    return p
+
+
+@jjit
+def _get_u_p_from_p_scalar(p, bounds):
+    lo, hi = bounds
+    p0 = 0.5 * (lo + hi)
+    u_p = _inverse_sigmoid(p, p0, BOUNDING_K, lo, hi)
+    return u_p
+
+
+_get_p_from_u_p_vmap = jjit(vmap(_get_p_from_u_p_scalar, in_axes=(0, 0)))
+_get_u_p_from_p_vmap = jjit(vmap(_get_u_p_from_p_scalar, in_axes=(0, 0)))
+
+
+@jjit
+def get_bounded_sfh_pdf_params(u_params):
+    u_params = jnp.array(
+        [getattr(u_params, u_pname) for u_pname in QseqUParams._fields]
+    )
+    params = _get_p_from_u_p_vmap(
+        jnp.array(u_params), jnp.array(SFH_PDF_QUENCH_PBOUNDS)
+    )
+    return QseqParams(*params)
+
+
+def get_unbounded_sfh_pdf_params(params):
+    params = jnp.array([getattr(params, pname) for pname in QseqParams._fields])
+    u_params = _get_u_p_from_p_vmap(
+        jnp.array(params), jnp.array(SFH_PDF_QUENCH_PBOUNDS)
+    )
+    return QseqUParams(*u_params)
+
+
+SFH_PDF_QUENCH_U_PARAMS = QseqUParams(
+    *get_unbounded_sfh_pdf_params(SFH_PDF_QUENCH_PARAMS)
+)

--- a/diffstarpop/loss_kernels/mstar_ssfr_loss_tpeak_satfrac.py
+++ b/diffstarpop/loss_kernels/mstar_ssfr_loss_tpeak_satfrac.py
@@ -1,0 +1,637 @@
+"""
+"""
+
+from collections import OrderedDict, namedtuple
+
+from diffsky.diffndhist import tw_ndhist_weighted
+from diffstar.utils import cumulative_mstar_formed
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import value_and_grad, vmap
+
+from ..kernels.defaults_tpeak_line_satfrac import (
+    DEFAULT_DIFFSTARPOP_U_PARAMS,
+    get_bounded_diffstarpop_params,
+)
+from ..mc_diffstarpop_tpeak_satfrac import mc_diffstar_sfh_galpop
+from .namedtuple_utils_tpeak_satfrac import (
+    array_to_tuple_new_diffstarpop_tpeak,
+    tuple_to_jax_array,
+)
+
+N_TIMES = 20
+
+_A = (None, 0)
+cumulative_mstar_formed_halopop = jjit(vmap(cumulative_mstar_formed, in_axes=_A))
+
+unbound_params_dict = OrderedDict(diffstarpop_u_params=DEFAULT_DIFFSTARPOP_U_PARAMS)
+UnboundParams = namedtuple("UnboundParams", list(unbound_params_dict.keys()))
+
+
+@jjit
+def _mse(pred, target):
+    diff = pred - target
+    return jnp.mean(diff**2)
+
+
+def _calculate_obs_data_kern(
+    tobs_target,
+    sfh_ms,
+    sfh_q,
+):
+    tarr = jnp.logspace(-1, jnp.log10(tobs_target), N_TIMES)
+    smh_ms = cumulative_mstar_formed_halopop(tarr, sfh_ms)
+    smh_q = cumulative_mstar_formed_halopop(tarr, sfh_q)
+    smh_ms_tobs = smh_ms[:, -1]
+    smh_q_tobs = smh_q[:, -1]
+    return smh_ms_tobs, smh_q_tobs
+
+
+calculate_obs_data = jjit(vmap(_calculate_obs_data_kern, in_axes=(0, 0, 0)))
+
+
+def _mc_diffstar_sfh_galpop_vmap_kern(
+    diffstarpop_params,
+    mah_params,
+    logmp0,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
+    ran_key,
+    tobs_target,
+):
+    tarr = jnp.logspace(-1, jnp.log10(tobs_target), N_TIMES)
+    res = mc_diffstar_sfh_galpop(
+        diffstarpop_params,
+        mah_params,
+        logmp0,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+        tarr,
+    )
+    return res
+
+
+_U = (None, *[0] * 8)
+mc_diffstar_sfh_galpop_vmap = jjit(vmap(_mc_diffstar_sfh_galpop_vmap_kern, in_axes=_U))
+
+
+# =====================================
+# Functions for P(Mstar | Mobs, zobs)
+# =====================================
+
+
+@jjit
+def compute_diff_histograms_mstar_atmobs_z(
+    logmstar_bins,
+    log_smh_table,
+    weight,
+):
+
+    n_halos = log_smh_table.shape[0]
+
+    nddata = log_smh_table.reshape((-1, 1))
+
+    sigma = jnp.mean(jnp.diff(logmstar_bins)) + jnp.zeros(n_halos)
+    ndsig = sigma.reshape((-1, 1))
+
+    ndbins_lo = logmstar_bins[:-1].reshape((-1, 1))
+    ndbins_hi = logmstar_bins[1:].reshape((-1, 1))
+
+    wcounts = tw_ndhist_weighted(nddata, ndsig, weight, ndbins_lo, ndbins_hi)
+
+    wcounts = wcounts / jnp.sum(wcounts)
+
+    return wcounts
+
+
+_A = (None, 0, 0)
+compute_diff_histograms_mstar_atmobs_z_vmap = jjit(
+    vmap(compute_diff_histograms_mstar_atmobs_z, in_axes=_A)
+)
+
+
+@jjit
+def mstar_kern_tobs(u_params, loss_data):
+    (
+        mah_params,
+        logmp0,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+        tobs_target,
+        logmstar_bins,
+        target_mstar_pdf,
+    ) = loss_data
+
+    diffstarpop_params = get_bounded_diffstarpop_params(u_params.diffstarpop_u_params)
+
+    _res = mc_diffstar_sfh_galpop_vmap(
+        diffstarpop_params,
+        mah_params,
+        logmp0,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+        tobs_target,
+    )
+    diffstar_params_ms, diffstar_params_q, sfh_ms, sfh_q, frac_q, mc_is_q = _res
+
+    smh_ms_tobs, smh_q_tobs = calculate_obs_data(tobs_target, sfh_ms, sfh_q)
+    sfh_ms_tobs, sfh_q_tobs = sfh_ms[:, :, -1], sfh_q[:, :, -1]
+
+    log_sfh_ms = jnp.log10(sfh_ms_tobs)
+    log_sfh_q = jnp.log10(sfh_q_tobs)
+    log_smh_ms = jnp.log10(smh_ms_tobs)
+    log_smh_q = jnp.log10(smh_q_tobs)
+
+    weight_q = jnp.ones_like(log_sfh_q) * frac_q
+    weight_ms = jnp.ones_like(log_sfh_ms) * (1 - frac_q)
+
+    log_smh = jnp.concatenate((log_smh_ms, log_smh_q), axis=1)
+    weight_smh = jnp.concatenate((weight_ms, weight_q), axis=1)
+
+    pred_mstar_pdf = compute_diff_histograms_mstar_atmobs_z_vmap(
+        logmstar_bins,
+        log_smh,
+        weight_smh,
+    )
+
+    return pred_mstar_pdf
+
+
+@jjit
+def loss_mstar_kern_tobs(u_params, loss_data):
+    target_mstar_pdf = loss_data[-1]
+    pred_mstar_pdf = mstar_kern_tobs(u_params, loss_data)
+
+    return _mse(pred_mstar_pdf, target_mstar_pdf) * 1000
+
+
+loss_mstar_kern_tobs_grad_kern = jjit(
+    value_and_grad(loss_mstar_kern_tobs, argnums=(0,))
+)
+
+
+def loss_mstar_kern_tobs_grad_wrapper(flat_uparams, loss_data):
+
+    namedtuple_uparams = array_to_tuple_new_diffstarpop_tpeak(
+        flat_uparams, UnboundParams
+    )
+    loss, grads = loss_mstar_kern_tobs_grad_kern(namedtuple_uparams, loss_data)
+    grads = tuple_to_jax_array(grads)
+
+    return loss, grads
+
+
+def get_pred_mstar_data_wrapper(flat_uparams, loss_data):
+
+    namedtuple_uparams = array_to_tuple_new_diffstarpop_tpeak(
+        flat_uparams, UnboundParams
+    )
+    pred_mstar_pdf = mstar_kern_tobs(namedtuple_uparams, loss_data)
+
+    return pred_mstar_pdf
+
+
+# =================================================
+# Functions for P(sSFR | Mstar, zobs) for centrals
+# =================================================
+
+
+def compute_diff_histograms_mstar_ssfr_atz(
+    log_smh_table,
+    log_ssfr_table,
+    weight,
+    ndbins_lo,
+    ndbins_hi,
+    logmstar_bins,
+    logssfr_bins,
+):
+    n_halos = log_smh_table.shape[0]
+
+    sigma_mstar = jnp.mean(jnp.diff(logmstar_bins)) + jnp.zeros(n_halos)
+    sigma_ssfr = jnp.mean(jnp.diff(logssfr_bins)) + jnp.zeros(n_halos)
+
+    ndsig = jnp.array([sigma_mstar, sigma_ssfr]).T
+    nddata = jnp.array([log_smh_table, log_ssfr_table]).T
+
+    wcounts = tw_ndhist_weighted(nddata, ndsig, weight, ndbins_lo, ndbins_hi)
+
+    wcounts = wcounts / jnp.sum(wcounts)
+
+    return wcounts
+
+
+_A = (0, 0, 0, None, None, None, None)
+compute_diff_histograms_mstar_ssfr_atmobs_z_vmap = jjit(
+    vmap(compute_diff_histograms_mstar_ssfr_atz, in_axes=_A)
+)
+
+
+@jjit
+def mstar_ssfr_kern_tobs(u_params, loss_data):
+    (
+        mah_params,
+        logmp0,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+        tobs_target,
+        ndbins_lo,
+        ndbins_hi,
+        logmstar_bins,
+        logssfr_bins,
+        nmhalo_pdf,
+        index_mhalo,
+        indx_pdf,
+        target_mstar_ids,
+        target_data,
+    ) = loss_data
+
+    diffstarpop_params = get_bounded_diffstarpop_params(u_params.diffstarpop_u_params)
+
+    _res = mc_diffstar_sfh_galpop_vmap(
+        diffstarpop_params,
+        mah_params,
+        logmp0,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+        tobs_target,
+    )
+    diffstar_params_ms, diffstar_params_q, sfh_ms, sfh_q, frac_q, mc_is_q = _res
+
+    smh_ms_tobs, smh_q_tobs = calculate_obs_data(tobs_target, sfh_ms, sfh_q)
+    sfh_ms_tobs, sfh_q_tobs = sfh_ms[:, :, -1], sfh_q[:, :, -1]
+
+    log_sfh_ms = jnp.log10(sfh_ms_tobs)
+    log_sfh_q = jnp.log10(sfh_q_tobs)
+    log_smh_ms = jnp.log10(smh_ms_tobs)
+    log_smh_q = jnp.log10(smh_q_tobs)
+
+    log_ssfrh_ms = log_sfh_ms - log_smh_ms
+    log_ssfrh_q = log_sfh_q - log_smh_q
+
+    log_ssfrh_ms = jnp.clip(log_ssfrh_ms, -12.0, None)
+    log_ssfrh_q = jnp.clip(log_ssfrh_q, -12.0, None)
+
+    weight_q = jnp.ones_like(log_sfh_q) * frac_q
+    weight_ms = jnp.ones_like(log_sfh_ms) * (1 - frac_q)
+
+    log_smh = jnp.concatenate((log_smh_ms, log_smh_q), axis=1)
+    log_ssfrh = jnp.concatenate((log_ssfrh_ms, log_ssfrh_q), axis=1)
+    weight = jnp.concatenate((weight_ms, weight_q), axis=1)
+
+    pred_mstar_ssfr_pdf = compute_diff_histograms_mstar_ssfr_atmobs_z_vmap(
+        log_smh,
+        log_ssfrh,
+        weight,
+        ndbins_lo,
+        ndbins_hi,
+        logmstar_bins,
+        logssfr_bins,
+    )
+
+    nms, nsf = len(logmstar_bins) - 1, len(logssfr_bins) - 1
+
+    pdfs_z0 = pred_mstar_ssfr_pdf[indx_pdf[0]].reshape((len(indx_pdf[0]), nms, nsf))
+    pdfs_z1 = pred_mstar_ssfr_pdf[indx_pdf[1]].reshape((len(indx_pdf[1]), nms, nsf))
+    pdfs_z2 = pred_mstar_ssfr_pdf[indx_pdf[2]].reshape((len(indx_pdf[2]), nms, nsf))
+    pdfs_z3 = pred_mstar_ssfr_pdf[indx_pdf[3]].reshape((len(indx_pdf[3]), nms, nsf))
+    pdfs_z4 = pred_mstar_ssfr_pdf[indx_pdf[4]].reshape((len(indx_pdf[4]), nms, nsf))
+    """
+    pdfs_z0 = pred_mstar_ssfr_pdf[0:8].reshape((8, nms, nsf))
+    pdfs_z1 = pred_mstar_ssfr_pdf[8:16].reshape((8, nms, nsf))
+    pdfs_z2 = pred_mstar_ssfr_pdf[16:24].reshape((8, nms, nsf))
+    pdfs_z3 = pred_mstar_ssfr_pdf[24:31].reshape((7, nms, nsf))
+    pdfs_z4 = pred_mstar_ssfr_pdf[31:38].reshape((7, nms, nsf))
+    """
+    pdfs_z0 = jnp.einsum("mab,m->ab", pdfs_z0, nmhalo_pdf[0, index_mhalo[0]])
+    pdfs_z1 = jnp.einsum("mab,m->ab", pdfs_z1, nmhalo_pdf[1, index_mhalo[1]])
+    pdfs_z2 = jnp.einsum("mab,m->ab", pdfs_z2, nmhalo_pdf[2, index_mhalo[2]])
+    pdfs_z3 = jnp.einsum("mab,m->ab", pdfs_z3, nmhalo_pdf[3, index_mhalo[3]])
+    pdfs_z4 = jnp.einsum("mab,m->ab", pdfs_z4, nmhalo_pdf[4, index_mhalo[4]])
+
+    pdfs_z0 = pdfs_z0[target_mstar_ids]
+    pdfs_z1 = pdfs_z1[target_mstar_ids]
+    pdfs_z2 = pdfs_z2[target_mstar_ids]
+    pdfs_z3 = pdfs_z3[target_mstar_ids]
+    pdfs_z4 = pdfs_z4[target_mstar_ids]
+
+    pdfs_z0 = pdfs_z0 / jnp.sum(pdfs_z0, axis=1)[:, None]
+    pdfs_z1 = pdfs_z1 / jnp.sum(pdfs_z1, axis=1)[:, None]
+    pdfs_z2 = pdfs_z2 / jnp.sum(pdfs_z2, axis=1)[:, None]
+    pdfs_z3 = pdfs_z3 / jnp.sum(pdfs_z3, axis=1)[:, None]
+    pdfs_z4 = pdfs_z4 / jnp.sum(pdfs_z4, axis=1)[:, None]
+
+    pred_data = jnp.array(
+        [
+            pdfs_z0,
+            pdfs_z1,
+            pdfs_z2,
+            pdfs_z3,
+            pdfs_z4,
+        ]
+    )
+
+    return pred_data
+
+
+@jjit
+def loss_mstar_ssfr_kern_tobs(u_params, loss_data):
+    target_data = loss_data[-1]
+
+    pred_data = mstar_ssfr_kern_tobs(u_params, loss_data)
+
+    return _mse(pred_data, target_data) * 1000
+
+
+loss_mstar_ssfr_kern_tobs_grad_kern = jjit(
+    value_and_grad(loss_mstar_ssfr_kern_tobs, argnums=(0,))
+)
+
+
+def loss_mstar_ssfr_kern_tobs_grad_wrapper(flat_uparams, loss_data):
+
+    namedtuple_uparams = array_to_tuple_new_diffstarpop_tpeak(
+        flat_uparams, UnboundParams
+    )
+    loss, grads = loss_mstar_ssfr_kern_tobs_grad_kern(namedtuple_uparams, loss_data)
+    grads = tuple_to_jax_array(grads)
+
+    return loss, grads
+
+
+def get_pred_mstar_ssfr_data_wrapper(flat_uparams, loss_data):
+
+    namedtuple_uparams = array_to_tuple_new_diffstarpop_tpeak(
+        flat_uparams, UnboundParams
+    )
+    pred_mstar_pdf = mstar_ssfr_kern_tobs(namedtuple_uparams, loss_data)
+
+    return pred_mstar_pdf
+
+
+# =================================================
+# Functions for P(sSFR | Mstar, zobs) for satellites
+# =================================================
+
+
+@jjit
+def mstar_ssfr_sat_kern_tobs(u_params, loss_data):
+    (
+        mah_params,
+        logmp0,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+        tobs_target,
+        ndbins_lo,
+        ndbins_hi,
+        logmstar_bins,
+        logssfr_bins,
+        nmhalo_pdf,
+        index_mhalo,
+        indx_pdf,
+        target_mstar_ids,
+        target_data,
+    ) = loss_data
+
+    diffstarpop_params = get_bounded_diffstarpop_params(u_params.diffstarpop_u_params)
+
+    _res = mc_diffstar_sfh_galpop_vmap(
+        diffstarpop_params,
+        mah_params,
+        logmp0,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+        tobs_target,
+    )
+    diffstar_params_ms, diffstar_params_q, sfh_ms, sfh_q, frac_q, mc_is_q = _res
+
+    smh_ms_tobs, smh_q_tobs = calculate_obs_data(tobs_target, sfh_ms, sfh_q)
+    sfh_ms_tobs, sfh_q_tobs = sfh_ms[:, :, -1], sfh_q[:, :, -1]
+
+    log_sfh_ms = jnp.log10(sfh_ms_tobs)
+    log_sfh_q = jnp.log10(sfh_q_tobs)
+    log_smh_ms = jnp.log10(smh_ms_tobs)
+    log_smh_q = jnp.log10(smh_q_tobs)
+
+    log_ssfrh_ms = log_sfh_ms - log_smh_ms
+    log_ssfrh_q = log_sfh_q - log_smh_q
+
+    log_ssfrh_ms = jnp.clip(log_ssfrh_ms, -12.0, None)
+    log_ssfrh_q = jnp.clip(log_ssfrh_q, -12.0, None)
+
+    weight_q = jnp.ones_like(log_sfh_q) * frac_q
+    weight_ms = jnp.ones_like(log_sfh_ms) * (1 - frac_q)
+
+    log_smh = jnp.concatenate((log_smh_ms, log_smh_q), axis=1)
+    log_ssfrh = jnp.concatenate((log_ssfrh_ms, log_ssfrh_q), axis=1)
+    weight = jnp.concatenate((weight_ms, weight_q), axis=1)
+
+    pred_mstar_ssfr_pdf = compute_diff_histograms_mstar_ssfr_atmobs_z_vmap(
+        log_smh,
+        log_ssfrh,
+        weight,
+        ndbins_lo,
+        ndbins_hi,
+        logmstar_bins,
+        logssfr_bins,
+    )
+
+    nms, nsf = len(logmstar_bins) - 1, len(logssfr_bins) - 1
+
+    pdfs_z0 = pred_mstar_ssfr_pdf[indx_pdf[0]].reshape((len(indx_pdf[0]), nms, nsf))
+    pdfs_z1 = pred_mstar_ssfr_pdf[indx_pdf[1]].reshape((len(indx_pdf[1]), nms, nsf))
+    pdfs_z2 = pred_mstar_ssfr_pdf[indx_pdf[2]].reshape((len(indx_pdf[2]), nms, nsf))
+    pdfs_z3 = pred_mstar_ssfr_pdf[indx_pdf[3]].reshape((len(indx_pdf[3]), nms, nsf))
+    pdfs_z4 = pred_mstar_ssfr_pdf[indx_pdf[4]].reshape((len(indx_pdf[4]), nms, nsf))
+    """
+    pdfs_z0 = pred_mstar_ssfr_pdf[0:8].reshape((8, nms, nsf))
+    pdfs_z1 = pred_mstar_ssfr_pdf[8:16].reshape((8, nms, nsf))
+    pdfs_z2 = pred_mstar_ssfr_pdf[16:24].reshape((8, nms, nsf))
+    pdfs_z3 = pred_mstar_ssfr_pdf[24:31].reshape((7, nms, nsf))
+    pdfs_z4 = pred_mstar_ssfr_pdf[31:38].reshape((7, nms, nsf))
+    """
+    pdfs_z0 = jnp.einsum("mab,m->ab", pdfs_z0, nmhalo_pdf[0, index_mhalo[0]])
+    pdfs_z1 = jnp.einsum("mab,m->ab", pdfs_z1, nmhalo_pdf[1, index_mhalo[1]])
+    pdfs_z2 = jnp.einsum("mab,m->ab", pdfs_z2, nmhalo_pdf[2, index_mhalo[2]])
+    pdfs_z3 = jnp.einsum("mab,m->ab", pdfs_z3, nmhalo_pdf[3, index_mhalo[3]])
+    pdfs_z4 = jnp.einsum("mab,m->ab", pdfs_z4, nmhalo_pdf[4, index_mhalo[4]])
+
+    pdfs_z0 = pdfs_z0[target_mstar_ids]
+    pdfs_z1 = pdfs_z1[target_mstar_ids]
+    pdfs_z2 = pdfs_z2[target_mstar_ids]
+    pdfs_z3 = pdfs_z3[target_mstar_ids]
+    pdfs_z4 = pdfs_z4[target_mstar_ids]
+
+    pdfs_z0 = pdfs_z0 / jnp.sum(pdfs_z0, axis=1)[:, None]
+    pdfs_z1 = pdfs_z1 / jnp.sum(pdfs_z1, axis=1)[:, None]
+    pdfs_z2 = pdfs_z2 / jnp.sum(pdfs_z2, axis=1)[:, None]
+    pdfs_z3 = pdfs_z3 / jnp.sum(pdfs_z3, axis=1)[:, None]
+    pdfs_z4 = pdfs_z4 / jnp.sum(pdfs_z4, axis=1)[:, None]
+
+    pred_data = jnp.array(
+        [
+            pdfs_z0,
+            pdfs_z1,
+            pdfs_z2,
+            pdfs_z3,
+            pdfs_z4,
+        ]
+    )
+
+    return pred_data
+
+
+@jjit
+def loss_mstar_ssfr_sat_kern_tobs(u_params, loss_data):
+    target_data = loss_data[-1]
+
+    pred_data = mstar_ssfr_sat_kern_tobs(u_params, loss_data)
+
+    return _mse(pred_data, target_data) * 1000
+
+
+loss_mstar_ssfr_sat_kern_tobs_grad_kern = jjit(
+    value_and_grad(loss_mstar_ssfr_sat_kern_tobs, argnums=(0,))
+)
+
+
+def loss_mstar_ssfr_sat_kern_tobs_grad_wrapper(flat_uparams, loss_data):
+
+    namedtuple_uparams = array_to_tuple_new_diffstarpop_tpeak(
+        flat_uparams, UnboundParams
+    )
+    loss, grads = loss_mstar_ssfr_sat_kern_tobs_grad_kern(namedtuple_uparams, loss_data)
+    grads = tuple_to_jax_array(grads)
+
+    return loss, grads
+
+
+def get_pred_mstar_ssfr_sat_data_wrapper(flat_uparams, loss_data):
+
+    namedtuple_uparams = array_to_tuple_new_diffstarpop_tpeak(
+        flat_uparams, UnboundParams
+    )
+    pred_mstar_pdf = mstar_ssfr_sat_kern_tobs(namedtuple_uparams, loss_data)
+
+    return pred_mstar_pdf
+
+
+# =================================================
+# Loss functions that combine multiple PDFs
+# =================================================
+
+
+@jjit
+def loss_combined_kern(u_params, loss_data_mstar, loss_data_ssfr_cen):
+    loss_mstar_ssfr_val_cen = loss_mstar_ssfr_kern_tobs(u_params, loss_data_ssfr_cen)
+    loss_mstar_val = loss_mstar_kern_tobs(u_params, loss_data_mstar)
+
+    return loss_mstar_ssfr_val_cen + loss_mstar_val
+
+
+loss_combined_grad_kern = jjit(value_and_grad(loss_combined_kern, argnums=(0,)))
+
+
+def loss_combined_wrapper(flat_uparams, loss_data_mstar, loss_data_ssfr_cen):
+
+    namedtuple_uparams = array_to_tuple_new_diffstarpop_tpeak(
+        flat_uparams, UnboundParams
+    )
+    loss, grads = loss_combined_grad_kern(
+        namedtuple_uparams, loss_data_mstar, loss_data_ssfr_cen
+    )
+    grads = tuple_to_jax_array(grads)
+
+    return loss, grads
+
+
+@jjit
+def loss_combined_3loss_kern(
+    u_params, loss_data_mstar, loss_data_ssfr_cen, loss_data_ssfr_sat
+):
+    loss_mstar_ssfr_val_cen = loss_mstar_ssfr_kern_tobs(u_params, loss_data_ssfr_cen)
+    loss_mstar_ssfr_val_sat = loss_mstar_ssfr_sat_kern_tobs(
+        u_params, loss_data_ssfr_sat
+    )
+    loss_mstar_val = loss_mstar_kern_tobs(u_params, loss_data_mstar)
+
+    return loss_mstar_ssfr_val_cen + loss_mstar_val + loss_mstar_ssfr_val_sat
+
+
+loss_combined_3loss_grad_kern = jjit(
+    value_and_grad(loss_combined_3loss_kern, argnums=(0,))
+)
+
+
+def loss_combined_3loss_wrapper(
+    flat_uparams, loss_data_mstar, loss_data_ssfr_cen, loss_data_ssfr_sat
+):
+
+    namedtuple_uparams = array_to_tuple_new_diffstarpop_tpeak(
+        flat_uparams, UnboundParams
+    )
+    loss, grads = loss_combined_3loss_grad_kern(
+        namedtuple_uparams, loss_data_mstar, loss_data_ssfr_cen, loss_data_ssfr_sat
+    )
+    grads = tuple_to_jax_array(grads)
+
+    return loss, grads
+
+
+# =================================================
+# Loss functions that combine p(Mstar|Mhalo) for cen and sat
+# =================================================
+
+
+@jjit
+def loss_combined_4loss_kern(
+    u_params,
+    loss_data_mstar_cen,
+    loss_data_mstar_sat,
+    loss_data_ssfr_cen,
+    loss_data_ssfr_sat,
+):
+    loss_mstar_ssfr_val_cen = loss_mstar_ssfr_kern_tobs(u_params, loss_data_ssfr_cen)
+    loss_mstar_ssfr_val_sat = loss_mstar_ssfr_sat_kern_tobs(
+        u_params, loss_data_ssfr_sat
+    )
+    loss_mstar_val_cen = loss_mstar_kern_tobs(u_params, loss_data_mstar_cen)
+    loss_mstar_val_sat = loss_mstar_kern_tobs(u_params, loss_data_mstar_sat)
+
+    losses = jnp.array(
+        [
+            loss_mstar_ssfr_val_cen,
+            loss_mstar_val_cen,
+            loss_mstar_val_sat,
+            loss_mstar_ssfr_val_sat,
+        ]
+    )
+
+    return jnp.sum(losses)
+
+
+loss_combined_4loss_grad_kern = jjit(
+    value_and_grad(loss_combined_4loss_kern, argnums=(0,))
+)

--- a/diffstarpop/loss_kernels/namedtuple_utils_tpeak_satfrac.py
+++ b/diffstarpop/loss_kernels/namedtuple_utils_tpeak_satfrac.py
@@ -1,0 +1,59 @@
+from collections import OrderedDict
+
+import jax
+import numpy as np
+from jax import numpy as jnp
+
+from ..kernels.defaults_tpeak_line_satfrac import (
+    DEFAULT_DIFFSTARPOP_U_PARAMS as DEFAULT_DIFFSTARPOP_U_PARAMS_tpeak,  # DEFAULT_DIFFSTARPOP_PARAMS,
+)
+
+
+def register_tuple_new_diffstarpop_tpeak(named_tuple_class):
+    jax.tree_util.register_pytree_node(
+        named_tuple_class,
+        # tell JAX how to unpack the NamedTuple to an iterable
+        lambda x: (tuple_to_jax_array(x), None),
+        # tell JAX how to pack it back into the proper NamedTuple structure
+        lambda _, x: array_to_tuple_new_diffstarpop_tpeak(x, named_tuple_class),
+    )
+
+
+def flatten_tuples(t):
+    for x in t:
+        if isinstance(x, tuple):
+            yield from flatten_tuples(x)
+        else:
+            yield x
+
+
+def tuple_to_jax_array(t):
+    res = tuple(flatten_tuples(t))
+    return jnp.asarray(res)
+
+
+def tuple_to_array(t):
+    res = tuple(flatten_tuples(t))
+    return np.asarray(res)
+
+
+def array_to_tuple_new_diffstarpop_tpeak(a, t):
+
+    count = 0
+
+    SFH_params = DEFAULT_DIFFSTARPOP_U_PARAMS_tpeak.u_sfh_pdf_cens_params
+    new_count = count + len(SFH_params)
+    new_sfh_pdf_cens_params_u_params = SFH_params._make(a[count:new_count])
+
+    SAT_params = DEFAULT_DIFFSTARPOP_U_PARAMS_tpeak.u_satquench_params
+    new_count2 = new_count + len(SAT_params)
+    new_satquenchpop_u_params = SAT_params._make(a[new_count:new_count2])
+
+    _up = (new_sfh_pdf_cens_params_u_params, new_satquenchpop_u_params)
+    new_diffstarpop_u_params = DEFAULT_DIFFSTARPOP_U_PARAMS_tpeak._make(_up)
+
+    new_dict = OrderedDict(diffstarpop_u_params=new_diffstarpop_u_params)
+
+    T = t(*list(new_dict.values()))
+
+    return T

--- a/diffstarpop/mc_diffstarpop_tpeak_satfrac.py
+++ b/diffstarpop/mc_diffstarpop_tpeak_satfrac.py
@@ -1,0 +1,462 @@
+"""This module implements kernels for Monte Carlo generating Diffstar SFHs
+"""
+
+from collections import namedtuple
+
+from diffstar import get_bounded_diffstar_params
+from diffstar.defaults import FB, LGT0
+from diffstar.sfh_model_tpeak import calc_sfh_galpop, calc_sfh_singlegal
+from jax import jit as jjit
+from jax import random as jran
+from jax import vmap
+
+from .kernels.diffstarpop_tpeak_line_satfrac import (
+    mc_diffstar_u_params_singlegal_kernel,
+)
+
+_mcdp_keys = ("diffstar_params_ms", "diffstar_params_q", "frac_q", "mc_is_q")
+MCDiffstarParams = namedtuple("MCDiffstarParams", _mcdp_keys)
+
+_mcd_keys = (
+    "diffstar_params_ms",
+    "diffstar_params_q",
+    "sfh_ms",
+    "sfh_q",
+    "frac_q",
+    "mc_is_q",
+)
+MCDiffstar = namedtuple("MCDiffstar", _mcd_keys)
+
+
+@jjit
+def mc_diffstar_sfh_singlegal(
+    diffstarpop_params,
+    mah_params,
+    logmp0,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
+    ran_key,
+    tarr,
+    lgt0=LGT0,
+    fb=FB,
+):
+    """Monte Carlo realization of a single point in Diffstar parameter space,
+    along with the computation of SFH for this point.
+
+    Parameters
+    ----------
+    diffstarpop_params : namedtuple
+        See defaults.DEFAULT_DIFFSTARPOP_PARAMS for an example
+
+    mah_params : namedtuple, length 5
+        mah_params is a tuple of floats
+        DiffmahParams = logmp, logtc, early_index, late_index, tpeak
+
+    logmp0 : ndarray of shape (ngals, )
+        logMhalo(t0)
+        logmp0 = logm0 when t_peak = t0
+        logmp0 < logm0 when t_peak < t0
+
+    lgmu_infall : float
+        Base-10 log of ratio Msub(t_infall)/Mhost(t_infall)
+        Set to 0.0 for centrals
+
+    logmhost_infall : float
+        Base-10 log of Mhost(t_infall)
+        Set to 0.0 for centrals
+
+    gyr_since_infall : float
+        Time since infall in Gyr
+        Set to -100.0 for centrals
+
+    ran_key : jax.random.PRNGKey
+        Single instance of a jax random seed
+
+    tarr : ndarray, shape (nt, )
+
+    lgt0 : float, optional
+        Base-10 log of the z=0 age of the Universe in Gyr
+        Default is set in diffstar.defaults
+        This variable should be self-consistently set with cosmology
+
+    fb : float, optional
+        Cosmic baryon fraction Ob0/Om0
+        Default is set in diffstar.defaults
+        This variable should be self-consistently set with cosmology
+
+    Returns
+    -------
+    diffstar_params_ms : namedtuple, length 5
+        ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+
+        DiffstarParams = ms_params, q_params
+            ms_params and q_params are tuples of floats
+            diffstar_params.ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+            diffstar_params.q_params = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+    diffstar_params_q : namedtuple, length 4
+        diffstar_params_q = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+        DiffstarParams = ms_params, q_params
+            ms_params and q_params are tuples of floats
+            diffstar_params.ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+            diffstar_params.q_params = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+    sfh_ms : ndarray, shape (nt, )
+        Star formation rate in units of Msun/yr for main sequence galaxy
+
+    sfh_q : ndarray, shape (nt, )
+        Star formation rate in units of Msun/yr for quenched galaxy
+
+    frac_q : scalar, float
+        Quenched fraction
+
+    mc_is_q : scalar, bool
+        True for a quenched galaxy and False for unquenched
+
+    """
+    mc_diffstar = mc_diffstar_params_singlegal(
+        diffstarpop_params,
+        logmp0,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+    )
+
+    sfh_ms = calc_sfh_singlegal(
+        mc_diffstar.diffstar_params_ms, mah_params, tarr, lgt0=lgt0, fb=fb
+    )
+    sfh_q = calc_sfh_singlegal(
+        mc_diffstar.diffstar_params_q, mah_params, tarr, lgt0=lgt0, fb=fb
+    )
+    return MCDiffstar(
+        mc_diffstar.diffstar_params_ms,
+        mc_diffstar.diffstar_params_q,
+        sfh_ms,
+        sfh_q,
+        mc_diffstar.frac_q,
+        mc_diffstar.mc_is_q,
+    )
+
+
+@jjit
+def mc_diffstar_params_singlegal(
+    diffstarpop_params,
+    logmp0,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
+    ran_key,
+):
+    """Monte Carlo realization of a single point in Diffstar parameter space.
+
+    Parameters
+    ----------
+    diffstarpop_params : namedtuple
+        See defaults.DEFAULT_DIFFSTARPOP_PARAMS for an example
+
+    logmp0 : ndarray of shape (ngals, )
+        logMhalo(t0)
+        logmp0 = logm0 when t_peak = t0
+        logmp0 < logm0 when t_peak < t0
+
+    lgmu_infall : float
+        Base-10 log of ratio Msub(t_infall)/Mhost(t_infall)
+        Set to 0.0 for centrals
+
+    logmhost_infall : float
+        Base-10 log of Mhost(t_infall)
+        Set to 0.0 for centrals
+
+    gyr_since_infall : float
+        Time since infall in Gyr
+        Set to -100.0 for centrals
+
+    ran_key : jax.random.PRNGKey
+        Single instance of a jax random seed
+
+    Returns
+    -------
+    diffstar_params_ms : namedtuple, length 5
+        ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+
+        DiffstarParams = ms_params, q_params
+            ms_params and q_params are tuples of floats
+            diffstar_params.ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+            diffstar_params.q_params = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+    diffstar_params_q : namedtuple, length 4
+        diffstar_params_q = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+        DiffstarParams = ms_params, q_params
+            ms_params and q_params are tuples of floats
+            diffstar_params.ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+            diffstar_params.q_params = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+    frac_q : scalar, float
+        Quenched fraction
+
+    mc_is_q : scalar, bool
+        True for a quenched galaxy and False for unquenched
+
+    """
+    _res = mc_diffstar_u_params_singlegal_kernel(
+        diffstarpop_params,
+        logmp0,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+    )
+    u_params_ms, u_params_qseq, frac_q, mc_is_q = _res
+    diffstar_params_q = get_bounded_diffstar_params(u_params_qseq)
+    diffstar_params_ms = get_bounded_diffstar_params(u_params_ms)
+
+    return MCDiffstarParams(diffstar_params_ms, diffstar_params_q, frac_q, mc_is_q)
+
+
+@jjit
+def mc_diffstar_u_params_singlegal(
+    diffstarpop_params,
+    logmp0,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
+    ran_key,
+):
+    """"""
+
+    _res = mc_diffstar_u_params_singlegal_kernel(
+        diffstarpop_params,
+        logmp0,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+    )
+    u_params_ms, u_params_qseq, frac_q, mc_is_q = _res
+    return u_params_ms, u_params_qseq, frac_q, mc_is_q
+
+
+_POP = (None, 0, 0, 0, 0, 0, 0)
+mc_diffstar_u_params_galpop_kernel = jjit(
+    vmap(mc_diffstar_u_params_singlegal, in_axes=_POP)
+)
+
+
+@jjit
+def mc_diffstar_u_params_galpop(
+    diffstarpop_params,
+    logmp0,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
+    ran_key,
+):
+    """"""
+    ngals = logmp0.size
+    ran_keys = jran.split(ran_key, ngals)
+    _res = mc_diffstar_u_params_galpop_kernel(
+        diffstarpop_params,
+        logmp0,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_keys,
+    )
+    diffstar_u_params_ms, diffstar_u_params_q, frac_q, mc_is_q = _res
+    return diffstar_u_params_ms, diffstar_u_params_q, frac_q, mc_is_q
+
+
+get_bounded_diffstar_params_galpop = jjit(vmap(get_bounded_diffstar_params, in_axes=0))
+
+
+@jjit
+def mc_diffstar_params_galpop(
+    diffstarpop_params,
+    logmp0,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
+    ran_key,
+):
+    """Monte Carlo realization of a population of points in Diffstar parameter space.
+
+    Parameters
+    ----------
+    diffstarpop_params : namedtuple
+        See defaults.DEFAULT_DIFFSTARPOP_PARAMS for an example
+
+    logmp0 : ndarray of shape (ngals, )
+        logMhalo(t0)
+        logmp0 = logm0 when t_peak = t0
+        logmp0 < logm0 when t_peak < t0
+
+    lgmu_infall : ndarray of shape (ngals, )
+        Base-10 log of ratio Msub(t_infall)/Mhost(t_infall)
+        Set to 0.0 for centrals
+
+    logmhost_infall : ndarray of shape (ngals, )
+        Base-10 log of Mhost(t_infall)
+        Set to 0.0 for centrals
+
+    gyr_since_infall : ndarray of shape (ngals, )
+        Time since infall in Gyr
+        Set to -100.0 for centrals
+
+    ran_key : jax.random.PRNGKey
+        Single instance of a jax random seed
+
+    Returns
+    -------
+    diffstar_params_ms : namedtuple, length 5
+        ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+
+        DiffstarParams = ms_params, q_params
+            ms_params and q_params are tuples of ndarrays of shape (ngals, )
+            diffstar_params.ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+            diffstar_params.q_params = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+    diffstar_params_q : namedtuple, length 4
+        diffstar_params_q = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+        DiffstarParams = ms_params, q_params
+            ms_params and q_params are tuples of ndarrays of shape (ngals, )
+            diffstar_params.ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+            diffstar_params.q_params = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+    frac_q : ndarray of shape (ngals, )
+        Quenched fraction
+
+    mc_is_q : ndarray of shape (ngals, )
+        Boolean is True for galaxies determined quenched by
+        the result of a stochastic Monte Carlo realization
+
+    """
+    _res = mc_diffstar_u_params_galpop(
+        diffstarpop_params,
+        logmp0,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+    )
+    diffstar_u_params_ms, diffstar_u_params_q, frac_q, mc_is_q = _res
+    diffstar_params_ms = get_bounded_diffstar_params_galpop(diffstar_u_params_ms)
+    diffstar_params_q = get_bounded_diffstar_params_galpop(diffstar_u_params_q)
+    return diffstar_params_ms, diffstar_params_q, frac_q, mc_is_q
+
+
+@jjit
+def mc_diffstar_sfh_galpop(
+    diffstarpop_params,
+    mah_params,
+    logmp0,
+    upid,
+    lgmu_infall,
+    logmhost_infall,
+    gyr_since_infall,
+    ran_key,
+    tarr,
+    lgt0=LGT0,
+    fb=FB,
+):
+    """Monte Carlo realization of a single point in Diffstar parameter space,
+    along with the computation of SFH for this point.
+
+    Parameters
+    ----------
+    diffstarpop_params : namedtuple
+        See defaults.DEFAULT_DIFFSTARPOP_PARAMS for an example
+
+    mah_params : namedtuple, length 5
+        mah_params is a tuple of ndarrays of shape (ngals, )
+        DiffmahParams = logmp, logtc, early_index, late_index, t_peak
+
+    logmp0 : ndarray of shape (ngals, )
+        logMhalo(t0)
+        logmp0 = logm0 when t_peak = t0
+        logmp0 < logm0 when t_peak < t0
+
+    lgmu_infall : ndarray of shape (ngals, )
+        Base-10 log of ratio Msub(t_infall)/Mhost(t_infall)
+        Set to 0.0 for centrals
+
+    logmhost_infall : ndarray of shape (ngals, )
+        Base-10 log of Mhost(t_infall)
+        Set to 0.0 for centrals
+
+    gyr_since_infall : ndarray of shape (ngals, )
+        Time since infall in Gyr
+        Set to -100.0 for centrals
+
+    ran_key : jax.random.PRNGKey
+        Single instance of a jax random seed
+
+    tarr : ndarray, shape (nt, )
+
+    lgt0 : float, optional
+        Base-10 log of the z=0 age of the Universe in Gyr
+        Default is set in diffstar.defaults
+        This variable should be self-consistently set with cosmology
+
+    fb : float, optional
+        Cosmic baryon fraction Ob0/Om0
+        Default is set in diffstar.defaults
+        This variable should be self-consistently set with cosmology
+
+    Returns
+    -------
+    diffstar_params_ms : namedtuple, length 5
+        ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+
+        DiffstarParams = ms_params, q_params
+            ms_params and q_params are tuples of ndarrays of shape (ngals, )
+            diffstar_params.ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+            diffstar_params.q_params = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+    diffstar_params_q : namedtuple, length 4
+        diffstar_params_q = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+        DiffstarParams = ms_params, q_params
+            ms_params and q_params are tuples of ndarrays of shape (ngals, )
+            diffstar_params.ms_params = lgmcrit, lgy_at_mcrit, indx_lo, indx_hi, tau_dep
+            diffstar_params.q_params = lg_qt, qlglgdt, lg_drop, lg_rejuv
+
+    sfh_ms : ndarray, shape (ngals, nt)
+        Star formation rate in units of Msun/yr for main sequence galaxy
+
+    sfh_q : ndarray, shape (ngals, nt)
+        Star formation rate in units of Msun/yr for quenched galaxy
+
+    frac_q : ndarray of shape (ngals, )
+        Quenched fraction
+
+    mc_is_q : ndarray of shape (ngals, )
+        Boolean is True for galaxies determined quenched by
+        the result of a stochastic Monte Carlo realization
+
+    """
+    _res = mc_diffstar_params_galpop(
+        diffstarpop_params,
+        logmp0,
+        upid,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+    )
+    diffstar_params_ms, diffstar_params_q, frac_q, mc_is_q = _res
+    sfh_ms = calc_sfh_galpop(diffstar_params_ms, mah_params, tarr, lgt0=lgt0, fb=fb)
+    sfh_q = calc_sfh_galpop(diffstar_params_q, mah_params, tarr, lgt0=lgt0, fb=fb)
+    return diffstar_params_ms, diffstar_params_q, sfh_ms, sfh_q, frac_q, mc_is_q

--- a/scripts/diagnostic_plots_satfrac.py
+++ b/scripts/diagnostic_plots_satfrac.py
@@ -1,0 +1,419 @@
+import os
+import h5py
+import numpy as np
+import jax.numpy as jnp
+import argparse
+
+from collections import OrderedDict, namedtuple
+
+from matplotlib import pyplot as plt
+from matplotlib.patches import Patch
+from matplotlib.lines import Line2D
+import matplotlib as mpl
+
+from diffstar.defaults import TODAY, LGT0
+from diffstar.sfh_model_tpeak import _cumulative_mstar_formed_vmap
+from diffmah.diffmah_kernels import DiffmahParams, mah_halopop
+
+from diffstarpop.mc_diffstarpop_tpeak_satfrac import mc_diffstar_sfh_galpop
+from diffstarpop.loss_kernels.namedtuple_utils_tpeak_satfrac import (
+    tuple_to_array,
+    register_tuple_new_diffstarpop_tpeak,
+    array_to_tuple_new_diffstarpop_tpeak,
+)
+from diffstarpop.kernels.defaults_tpeak_line_satfrac import (
+    DEFAULT_DIFFSTARPOP_U_PARAMS,
+    DEFAULT_DIFFSTARPOP_PARAMS,
+    get_bounded_diffstarpop_params,
+)
+from fit_get_loss_helpers_satfrac import (
+    get_loss_data_smhm,
+    get_loss_data_pdfs_mstar,
+    get_loss_data_pdfs_ssfr_central,
+    get_loss_data_pdfs_ssfr_satellite,
+)
+
+from diffstarpop.loss_kernels.mstar_ssfr_loss_tpeak_satfrac import (
+    get_pred_mstar_data_wrapper,
+    get_pred_mstar_ssfr_data_wrapper,
+    get_pred_mstar_ssfr_sat_data_wrapper,
+)
+
+BEBOP_SMHM_MEAN_DATA = "/lcrc/project/halotools/alarcon/results/"
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-indir", help="input drn", type=str, default=BEBOP_SMHM_MEAN_DATA
+    )
+    parser.add_argument(
+        "-outdir", help="output drn", type=str, default=BEBOP_SMHM_MEAN_DATA
+    )
+    parser.add_argument(
+        "--params_path",
+        type=str,
+        default=None,
+        help="Path were diffstarpop params are stored",
+    )
+    args = parser.parse_args()
+    indir = args.indir
+    outdir = args.outdir
+    params_path = args.params_path
+
+    if params_path is None:
+        all_u_params = tuple_to_array(DEFAULT_DIFFSTARPOP_U_PARAMS)
+    else:
+        params = np.load(params_path)
+        all_u_params = params["diffstarpop_u_params"]
+
+    # Register params ---------------------------------------------
+
+    unbound_params_dict = OrderedDict(diffstarpop_u_params=DEFAULT_DIFFSTARPOP_U_PARAMS)
+    UnboundParams = namedtuple("UnboundParams", list(unbound_params_dict.keys()))
+    register_tuple_new_diffstarpop_tpeak(UnboundParams)
+
+    diffstarpop_u_params = array_to_tuple_new_diffstarpop_tpeak(
+        all_u_params, UnboundParams
+    )
+
+    diffstarpop_params = get_bounded_diffstarpop_params(
+        diffstarpop_u_params.diffstarpop_u_params
+    )
+
+    # Load SMHM data ---------------------------------------------
+    nhalos = 10
+    _, plot_data_SMHM = get_loss_data_smhm(indir, nhalos)
+    _, plot_data_pdf = get_loss_data_pdfs_mstar(indir, nhalos)
+    _, plot_data_pdf_ssfr_cen = get_loss_data_pdfs_ssfr_central(indir, nhalos)
+    _, plot_data_pdf_ssfr_sat = get_loss_data_pdfs_ssfr_satellite(indir, nhalos)
+
+    # ============
+    # Plots SMHM
+    # ============
+    print("Making SMHM plot...")
+
+    (
+        age_targets,
+        logmh_binsc,
+        tobs_id,
+        logmh_id,
+        tarr_logm0,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+        redshift_targets,
+        smhm,
+        mah_params_samp,
+    ) = plot_data_SMHM
+
+    mstar_plot = np.zeros((len(age_targets), len(logmh_binsc)))
+    mstar_plot_grad = np.zeros((len(age_targets), len(logmh_binsc)))
+
+    smhm_plot = smhm.copy()
+
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+        print("Age target:", t_target)
+        tarr = np.logspace(-1, np.log10(t_target), 50)
+
+        for j in range(len(logmh_binsc)):
+
+            sel = (tobs_id == i) & (logmh_id == j)
+            if sel.sum() < 50:
+                smhm_plot[i, j] = np.nan
+                mstar_plot[i, j] = np.nan
+                continue
+
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            lomg0_vals = log_mah_fit[:, -1]
+            res = mc_diffstar_sfh_galpop(
+                diffstarpop_params,
+                mah_pars_ntuple,
+                lomg0_vals,
+                np.ones(sel.sum()) * lgmu_infall,
+                np.ones(sel.sum()) * logmhost_infall,
+                np.ones(sel.sum()) * gyr_since_infall,
+                ran_key,
+                tarr,
+            )
+
+            (
+                diffstar_params_ms,
+                diffstar_params_q,
+                sfh_ms,
+                sfh_q,
+                frac_q,
+                mc_is_q,
+            ) = res
+            mstar_q = _cumulative_mstar_formed_vmap(tarr, sfh_q)
+            mstar_ms = _cumulative_mstar_formed_vmap(tarr, sfh_ms)
+            mean_mstar_grad_vals = mstar_q[:, -1] * frac_q + mstar_ms[:, -1] * (
+                1 - frac_q
+            )
+            mean_mstar_grad = jnp.mean(jnp.log10(mean_mstar_grad_vals))
+
+            mean_mstar_plot_vals = mstar_q[:, -1] * mc_is_q.astype(int).astype(
+                float
+            ) + mstar_ms[:, -1] * (1.0 - mc_is_q.astype(int))
+            mean_mstar_plot_vals = jnp.mean(jnp.log10(mean_mstar_plot_vals))
+            mstar_plot[i, j] = mean_mstar_plot_vals
+            mstar_plot_grad[i, j] = mean_mstar_grad
+            # break
+
+            cmap = plt.get_cmap("plasma")(redshift_targets / redshift_targets.max())
+
+    fig, ax = plt.subplots(1, 1, figsize=(6, 4))
+    for i in range(len(smhm)):
+        ax.plot(10**logmh_binsc, 10 ** smhm_plot[i], color=cmap[i])
+        ax.plot(10**logmh_binsc, 10 ** mstar_plot[i], color=cmap[i], ls="--")
+
+    norm = mpl.colors.Normalize(vmin=0, vmax=2)
+
+    fig.colorbar(
+        mpl.cm.ScalarMappable(norm=norm, cmap=mpl.cm.plasma),
+        ax=ax,
+        label="Redshift",
+    )
+
+    ax.set_yscale("log")
+    ax.set_xscale("log")
+    ax.set_xlim(9e10, 1e15)
+
+    ax.set_ylabel(
+        r"$\langle M_\star(t_{\rm obs})| M_{\rm halo}(t_{\rm obs}) \rangle$ $[M_\odot]$"
+    )
+    ax.set_xlabel(r"$M_{\rm halo}(t_{\rm obs})$ $[M_\odot]$")
+    plt.savefig(outdir + "smhm_logsm.png", bbox_inches="tight", dpi=300)
+    plt.clf()
+
+    # =====================================
+    # Plots for P(Mstar | Mobs, zobs)
+    # =====================================
+    print("Making plot Mstar PDFs...")
+
+    (
+        logmstar_bins_pdf,
+        mstar_wcounts,
+        age_targets,
+        redshift_targets,
+        tobs_id,
+        logmh_id,
+        logmh_binsc,
+        loss_data_mstar_pred,
+    ) = plot_data_pdf
+
+    _mstar_counts_pred = get_pred_mstar_data_wrapper(all_u_params, loss_data_mstar_pred)
+
+    mstar_counts_pred = np.zeros_like(mstar_wcounts) * np.nan
+    ij = 0
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j)
+
+            # if sel.sum() == 0: continue
+            if sel.sum() < 50:
+                continue
+            mstar_counts_pred[i, j] = _mstar_counts_pred[ij]
+            ij += 1
+
+    fig, ax = plt.subplots(5, 1, figsize=(12, 16), sharex=False)
+
+    colors_mstar = plt.get_cmap("viridis")(np.linspace(0, 1, 11))
+
+    for i in range(len(age_targets)):
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j)
+            if sel.sum() < 50:
+                continue
+            ax[i].fill_between(
+                logmstar_bins_pdf[1:],
+                0.0,
+                mstar_wcounts[i, j] / mstar_wcounts[i, j].sum(),
+                color=colors_mstar[j],
+                alpha=0.2,
+            )
+            ax[i].plot(
+                logmstar_bins_pdf[1:],
+                mstar_counts_pred[i, j],
+                color=colors_mstar[j],
+                ls="--",
+            )
+
+        ax[i].set_ylim(0, 0.3)
+        ax[i].set_xlim(7, 12.0)
+        ax[i].set_ylabel(r"$P(M_\star(t_{\rm obs})| M_{\rm halo}(t_{\rm obs}))$")
+        ax[i].set_title(r"${\rm Redshift}=%.1f$" % redshift_targets[i], y=0.85, x=0.9)
+        if i < 4:
+            ax[i].set_xticklabels([])
+
+    legend_elements = [
+        Patch(
+            facecolor=colors_mstar[0],
+            edgecolor="none",
+            label=r"$M_{\rm halo}(t_{\rm obs}))=11$",
+            alpha=0.7,
+        ),
+        Patch(
+            facecolor=colors_mstar[-1],
+            edgecolor="none",
+            label=r"$M_{\rm halo}(t_{\rm obs}))=14.5$",
+            alpha=0.7,
+        ),
+        Line2D([0], [0], color="k", ls="--", label="Diffstarpop"),
+    ]
+    ax[0].legend(handles=legend_elements, loc=2, fontsize=14)
+    ax[4].set_xlabel(r"$\log M_\star(t_{\rm obs})$")
+
+    fig.subplots_adjust(hspace=0.08)
+
+    plt.savefig(
+        outdir + "pdf_mstar.png",
+        bbox_inches="tight",
+        dpi=250,
+    )
+    plt.clf()
+
+    # =================================================
+    # Plots P(sSFR | Mstar, zobs) for centrals
+    # =================================================
+    print("Making plot sSFR PDFs for centrals...")
+
+    (
+        target_mstar_ids,
+        logssfr_binsc_pdf,
+        target_data,
+        loss_data_ssfr_pred,
+    ) = plot_data_pdf_ssfr_cen
+
+    bestfit_data = get_pred_mstar_ssfr_data_wrapper(all_u_params, loss_data_ssfr_pred)
+
+    fig, ax = plt.subplots(5, 1, figsize=(12, 16), sharex=False)
+
+    colors_ssfr = plt.get_cmap("plasma")(np.linspace(0.2, 0.8, len(target_mstar_ids)))
+
+    for i in range(5):
+
+        for j in range(len(target_mstar_ids)):
+
+            ax[i].fill_between(
+                logssfr_binsc_pdf,
+                0.0,
+                target_data[i, j],
+                color=colors_ssfr[j],
+                alpha=0.2,
+            )
+            ax[i].plot(
+                logssfr_binsc_pdf, bestfit_data[i, j], color=colors_ssfr[j], ls="--"
+            )
+
+        ax[i].set_ylim(0, 0.35)
+        ax[i].set_ylabel(
+            r"$P_{\rm cen}({\rm sSFR}(t_{\rm obs})| M_\star(t_{\rm obs}))$"
+        )
+        ax[i].set_title(r"${\rm Redshift}=%.1f$" % redshift_targets[i], y=0.85, x=0.9)
+        if i < 4:
+            ax[i].set_xticklabels([])
+
+    legend_elements = [
+        Patch(
+            facecolor=colors_ssfr[0],
+            edgecolor="none",
+            label=r"$M_\star(t_{\rm obs})=9.0$",
+            alpha=0.7,
+        ),
+        Patch(
+            facecolor=colors_ssfr[-1],
+            edgecolor="none",
+            label=r"$M_\star(t_{\rm obs})=11.5$",
+            alpha=0.7,
+        ),
+        Line2D([0], [0], color="k", ls="--", label="Diffstarpop"),
+    ]
+    ax[0].legend(handles=legend_elements, loc=2, fontsize=14)
+    ax[4].set_xlabel(r"$\log {\rm sSFR}(t_{\rm obs})$")
+
+    fig.subplots_adjust(hspace=0.08)
+    fig.suptitle("Centrals", y=0.9)
+    plt.savefig(
+        outdir + "pdf_ssfr_centrals.png",
+        bbox_inches="tight",
+        dpi=250,
+    )
+    plt.clf()
+
+    # =================================================
+    # Plots P(sSFR | Mstar, zobs) for satellites
+    # =================================================
+
+    print("Making plot sSFR PDFs for centrals...")
+
+    (
+        target_mstar_ids,
+        logssfr_binsc_pdf,
+        target_data_sat,
+        loss_data_ssfr_sat_pred,
+    ) = plot_data_pdf_ssfr_sat
+
+    bestfit_data = get_pred_mstar_ssfr_sat_data_wrapper(
+        all_u_params, loss_data_ssfr_sat_pred
+    )
+
+    fig, ax = plt.subplots(5, 1, figsize=(12, 16), sharex=False)
+
+    colors_ssfr = plt.get_cmap("plasma")(np.linspace(0.2, 0.8, len(target_mstar_ids)))
+
+    for i in range(5):
+
+        for j in range(len(target_mstar_ids)):
+
+            ax[i].fill_between(
+                logssfr_binsc_pdf,
+                0.0,
+                target_data_sat[i, j],
+                color=colors_ssfr[j],
+                alpha=0.2,
+            )
+            ax[i].plot(
+                logssfr_binsc_pdf, bestfit_data[i, j], color=colors_ssfr[j], ls="--"
+            )
+
+        ax[i].set_ylim(0, 0.35)
+        ax[i].set_ylabel(
+            r"$P_{\rm cen}({\rm sSFR}(t_{\rm obs})| M_\star(t_{\rm obs}))$"
+        )
+        ax[i].set_title(r"${\rm Redshift}=%.1f$" % redshift_targets[i], y=0.85, x=0.9)
+        if i < 4:
+            ax[i].set_xticklabels([])
+
+    legend_elements = [
+        Patch(
+            facecolor=colors_ssfr[0],
+            edgecolor="none",
+            label=r"$M_\star(t_{\rm obs})=9.0$",
+            alpha=0.7,
+        ),
+        Patch(
+            facecolor=colors_ssfr[-1],
+            edgecolor="none",
+            label=r"$M_\star(t_{\rm obs})=11.5$",
+            alpha=0.7,
+        ),
+        Line2D([0], [0], color="k", ls="--", label="Diffstarpop"),
+    ]
+    ax[0].legend(handles=legend_elements, loc="upper center", fontsize=14)
+    ax[4].set_xlabel(r"$\log {\rm sSFR}(t_{\rm obs})$")
+
+    fig.subplots_adjust(hspace=0.08)
+    fig.suptitle("Satellites", y=0.9)
+
+    plt.savefig(
+        outdir + "pdf_ssfr_satellites.png",
+        bbox_inches="tight",
+        dpi=250,
+    )
+    plt.clf()

--- a/scripts/diagnostic_plots_satfrac.py
+++ b/scripts/diagnostic_plots_satfrac.py
@@ -106,6 +106,7 @@ if __name__ == "__main__":
         redshift_targets,
         smhm,
         mah_params_samp,
+        upid_samp,
     ) = plot_data_SMHM
 
     mstar_plot = np.zeros((len(age_targets), len(logmh_binsc)))
@@ -129,10 +130,12 @@ if __name__ == "__main__":
             mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, sel])
             dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
             lomg0_vals = log_mah_fit[:, -1]
+            upid_vals = upid_samp[sel]
             res = mc_diffstar_sfh_galpop(
                 diffstarpop_params,
                 mah_pars_ntuple,
                 lomg0_vals,
+                upid_vals,
                 np.ones(sel.sum()) * lgmu_infall,
                 np.ones(sel.sum()) * logmhost_infall,
                 np.ones(sel.sum()) * gyr_since_infall,

--- a/scripts/fit_get_loss_helpers.py
+++ b/scripts/fit_get_loss_helpers.py
@@ -877,3 +877,399 @@ def get_loss_data_pdfs_ssfr_satellite(indir, nhalos):
     )
 
     return loss_data_ssfr_sat, plot_data
+
+
+def get_loss_data_pdfs_mstar_cen(indir, nhalos):
+    # Load PDF data ---------------------------------------------
+    print("Loading PDF Mstar for centrals data...")
+
+    fname = os.path.join(indir, "smdpl_smhm.h5")
+    with h5py.File(fname, "r") as hdf:
+        redshift_targets = hdf["redshift_targets"][:]
+        smhm_diff = hdf["smhm_diff"][:]
+        smhm = hdf["smhm"][:]
+        logmh_bins = hdf["logmh_bins"][:]
+        age_targets = hdf["age_targets"][:]
+        hist = hdf["hist"][:]
+        counts = hdf["counts"][:]
+        counts_cen = hdf["counts_cen"][:]
+        counts_sat = hdf["counts_sat"][:]
+
+    logmh_binsc = 0.5 * (logmh_bins[1:] + logmh_bins[:-1])
+
+    fname = os.path.join(indir, "smdpl_smhm_samples_haloes.h5")
+    with h5py.File(fname, "r") as hdf:
+        logmh_id = hdf["logmh_id"][:]
+        logmh_val = hdf["logmh_id"][:]
+        mah_params_samp = hdf["mah_params_samp"][:]
+        ms_params_samp = hdf["ms_params_samp"][:]
+        q_params_samp = hdf["q_params_samp"][:]
+        upid_samp = hdf["upid_samp"][:]
+        tobs_id = hdf["tobs_id"][:]
+        tobs_val = hdf["tobs_val"][:]
+        redshift_val = hdf["redshift_val"][:]
+
+    fname = os.path.join(indir, "smdpl_mstar_ssfr.h5")
+    with h5py.File(fname, "r") as hdf:
+        mstar_wcounts = hdf["mstar_wcounts"][:]
+        mstar_counts = hdf["mstar_counts"][:]
+        mstar_ssfr_wcounts_cent = hdf["mstar_ssfr_wcounts_cent"][:]
+        mstar_ssfr_wcounts_sat = hdf["mstar_ssfr_wcounts_sat"][:]
+        logssfr_bins_pdf = hdf["logssfr_bins_pdf"][:]
+        logmstar_bins_pdf = hdf["logmstar_bins_pdf"][:]
+        """
+        hdfout["mstar_wcounts"] = mstar_wcounts
+        hdfout["mstar_counts"] = mstar_counts
+        hdfout["mstar_ssfr_wcounts_cent"] = mstar_ssfr_wcounts_cent
+        hdfout["mstar_ssfr_wcounts_sat"] = mstar_ssfr_wcounts_sat
+        hdfout["logmh_bins"] = smhm_utils.LOGMH_BINS
+        hdfout["logmstar_bins_pdf"] = smhm_utils.LOGMSTAR_BINS_PDF
+        hdfout["logssfr_bins_pdf"] = smhm_utils.LOGSSFR_BINS_PDF
+        hdfout["redshift_targets"] = redshift_targets
+        hdfout["age_targets"] = age_targets
+        """
+
+    mstar_wcounts_cen = np.sum(mstar_ssfr_wcounts_cent, axis=3)
+    mstar_wcounts_sat = np.sum(mstar_ssfr_wcounts_sat, axis=3)
+
+    logssfr_binsc_pdf = 0.5 * (logssfr_bins_pdf[1:] + logssfr_bins_pdf[:-1])
+    logmstar_binsc_pdf = 0.5 * (logmstar_bins_pdf[1:] + logmstar_bins_pdf[:-1])
+
+    # Create loss_data ---------------------------------------------
+    print("Creating loss data...")
+
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    # Centrals
+    mah_params_data = []
+    logmp0_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+    mstar_counts_target = []
+
+    tarr_logm0 = np.logspace(-1, LGT0, 50)
+
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j) & (upid_samp == -1)
+
+            if sel.sum() < 50:
+                continue
+            replace = True if sel.sum() < nhalos else False
+            arange_sel = np.arange(len(tobs_id))[sel]
+            arange_sel = np.random.choice(arange_sel, nhalos, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mstar_counts_target.append(
+                mstar_wcounts_cen[i, j] / mstar_wcounts_cen[i, j].sum()
+            )
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+        # break
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+    mstar_counts_target = np.array(mstar_counts_target)
+
+    ran_key_data = jran.split(ran_key, len(mstar_counts_target))
+    loss_data_mstar = (
+        mah_params_data,
+        logmp0_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        logmstar_bins_pdf,
+        mstar_counts_target,
+    )
+
+    # Create loss_data for plot ---------------------------------------------
+    print("Creating loss data for plot...")
+    nhalos_plot = 10000
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    mah_params_data = []
+    logmp0_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+    mstar_counts_target = []
+
+    tarr_logm0 = np.logspace(-1, LGT0, 50)
+
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j) & (upid_samp == -1)
+
+            if sel.sum() < 50:
+                continue
+            replace = True if sel.sum() < nhalos_plot else False
+            arange_sel = np.arange(len(tobs_id))[sel]
+            arange_sel = np.random.choice(arange_sel, nhalos_plot, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mstar_counts_target.append(
+                mstar_wcounts_cen[i, j] / mstar_wcounts_cen[i, j].sum()
+            )
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+        # break
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+    mstar_counts_target = np.array(mstar_counts_target)
+
+    ran_key_data = jran.split(ran_key, len(mstar_counts_target))
+    loss_data_mstar_pred = (
+        mah_params_data,
+        logmp0_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        logmstar_bins_pdf,
+        mstar_counts_target,
+    )
+    plot_data = (
+        logmstar_bins_pdf,
+        mstar_wcounts,
+        age_targets,
+        redshift_targets,
+        tobs_id,
+        logmh_id,
+        logmh_binsc,
+        loss_data_mstar_pred,
+    )
+
+    return loss_data_mstar, plot_data
+
+
+def get_loss_data_pdfs_mstar_sat(indir, nhalos):
+    # Load PDF data ---------------------------------------------
+    print("Loading PDF Mstar for satellites data...")
+
+    fname = os.path.join(indir, "smdpl_smhm.h5")
+    with h5py.File(fname, "r") as hdf:
+        redshift_targets = hdf["redshift_targets"][:]
+        smhm_diff = hdf["smhm_diff"][:]
+        smhm = hdf["smhm"][:]
+        logmh_bins = hdf["logmh_bins"][:]
+        age_targets = hdf["age_targets"][:]
+        hist = hdf["hist"][:]
+        counts = hdf["counts"][:]
+        counts_cen = hdf["counts_cen"][:]
+        counts_sat = hdf["counts_sat"][:]
+
+    logmh_binsc = 0.5 * (logmh_bins[1:] + logmh_bins[:-1])
+
+    fname = os.path.join(indir, "smdpl_smhm_samples_haloes.h5")
+    with h5py.File(fname, "r") as hdf:
+        logmh_id = hdf["logmh_id"][:]
+        logmh_val = hdf["logmh_id"][:]
+        mah_params_samp = hdf["mah_params_samp"][:]
+        ms_params_samp = hdf["ms_params_samp"][:]
+        q_params_samp = hdf["q_params_samp"][:]
+        upid_samp = hdf["upid_samp"][:]
+        tobs_id = hdf["tobs_id"][:]
+        tobs_val = hdf["tobs_val"][:]
+        redshift_val = hdf["redshift_val"][:]
+
+    fname = os.path.join(indir, "smdpl_mstar_ssfr.h5")
+    with h5py.File(fname, "r") as hdf:
+        mstar_wcounts = hdf["mstar_wcounts"][:]
+        mstar_counts = hdf["mstar_counts"][:]
+        mstar_ssfr_wcounts_cent = hdf["mstar_ssfr_wcounts_cent"][:]
+        mstar_ssfr_wcounts_sat = hdf["mstar_ssfr_wcounts_sat"][:]
+        logssfr_bins_pdf = hdf["logssfr_bins_pdf"][:]
+        logmstar_bins_pdf = hdf["logmstar_bins_pdf"][:]
+        """
+        hdfout["mstar_wcounts"] = mstar_wcounts
+        hdfout["mstar_counts"] = mstar_counts
+        hdfout["mstar_ssfr_wcounts_cent"] = mstar_ssfr_wcounts_cent
+        hdfout["mstar_ssfr_wcounts_sat"] = mstar_ssfr_wcounts_sat
+        hdfout["logmh_bins"] = smhm_utils.LOGMH_BINS
+        hdfout["logmstar_bins_pdf"] = smhm_utils.LOGMSTAR_BINS_PDF
+        hdfout["logssfr_bins_pdf"] = smhm_utils.LOGSSFR_BINS_PDF
+        hdfout["redshift_targets"] = redshift_targets
+        hdfout["age_targets"] = age_targets
+        """
+
+    mstar_wcounts_cen = np.sum(mstar_ssfr_wcounts_cent, axis=3)
+    mstar_wcounts_sat = np.sum(mstar_ssfr_wcounts_sat, axis=3)
+
+    logssfr_binsc_pdf = 0.5 * (logssfr_bins_pdf[1:] + logssfr_bins_pdf[:-1])
+    logmstar_binsc_pdf = 0.5 * (logmstar_bins_pdf[1:] + logmstar_bins_pdf[:-1])
+
+    # Create loss_data ---------------------------------------------
+    print("Creating loss data...")
+
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    # Centrals
+    mah_params_data = []
+    logmp0_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+    mstar_counts_target = []
+
+    tarr_logm0 = np.logspace(-1, LGT0, 50)
+
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j) & (upid_samp != -1)
+
+            if sel.sum() < 50:
+                continue
+            replace = True if sel.sum() < nhalos else False
+            arange_sel = np.arange(len(tobs_id))[sel]
+            arange_sel = np.random.choice(arange_sel, nhalos, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mstar_counts_target.append(
+                mstar_wcounts_sat[i, j] / mstar_wcounts_sat[i, j].sum()
+            )
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+        # break
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+    mstar_counts_target = np.array(mstar_counts_target)
+
+    ran_key_data = jran.split(ran_key, len(mstar_counts_target))
+    loss_data_mstar = (
+        mah_params_data,
+        logmp0_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        logmstar_bins_pdf,
+        mstar_counts_target,
+    )
+
+    # Create loss_data for plot ---------------------------------------------
+    print("Creating loss data for plot...")
+    nhalos_plot = 10000
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    mah_params_data = []
+    logmp0_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+    mstar_counts_target = []
+
+    tarr_logm0 = np.logspace(-1, LGT0, 50)
+
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j) & (upid_samp != -1)
+
+            if sel.sum() < 50:
+                continue
+            replace = True if sel.sum() < nhalos_plot else False
+            arange_sel = np.arange(len(tobs_id))[sel]
+            arange_sel = np.random.choice(arange_sel, nhalos_plot, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mstar_counts_target.append(
+                mstar_wcounts_sat[i, j] / mstar_wcounts_sat[i, j].sum()
+            )
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+        # break
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+    mstar_counts_target = np.array(mstar_counts_target)
+
+    ran_key_data = jran.split(ran_key, len(mstar_counts_target))
+    loss_data_mstar_pred = (
+        mah_params_data,
+        logmp0_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        logmstar_bins_pdf,
+        mstar_counts_target,
+    )
+    plot_data = (
+        logmstar_bins_pdf,
+        mstar_wcounts,
+        age_targets,
+        redshift_targets,
+        tobs_id,
+        logmh_id,
+        logmh_binsc,
+        loss_data_mstar_pred,
+    )
+
+    return loss_data_mstar, plot_data

--- a/scripts/fit_get_loss_helpers_satfrac.py
+++ b/scripts/fit_get_loss_helpers_satfrac.py
@@ -1,0 +1,1315 @@
+"""
+"""
+
+import os
+import h5py
+import numpy as np
+from diffmah.diffmah_kernels import DiffmahParams, mah_halopop
+from diffstar.defaults import LGT0
+from jax import random as jran
+
+
+def get_loss_data_smhm(indir, nhalos):
+    # Load SMHM data ---------------------------------------------
+    print("Loading SMHM data...")
+
+    with h5py.File(indir + "smdpl_smhm.h5", "r") as hdf:
+        redshift_targets = hdf["redshift_targets"][:]
+        # smhm_diff = hdf["smhm_diff"][:]
+        smhm = hdf["smhm"][:]
+        logmh_bins = hdf["logmh_bins"][:]
+        age_targets = hdf["age_targets"][:]
+        """
+            hdfout["counts_diff"] = wcounts
+            hdfout["hist_diff"] = whist
+            hdfout["counts"] = counts
+            hdfout["hist"] = hist
+            hdfout["smhm_diff"] = whist / wcounts
+            hdfout["smhm"] = hist / counts
+            hdfout["logmh_bins"] = smhm_utils.LOGMH_BINS
+            hdfout["subvol_used"] = subvol_used
+        """
+
+    logmh_binsc = 0.5 * (logmh_bins[1:] + logmh_bins[:-1])
+
+    with h5py.File(indir + "smdpl_smhm_samples_haloes.h5", "r") as hdf:
+        logmh_id = hdf["logmh_id"][:]
+        # logmh_val = hdf["logmh_id"][:]
+        mah_params_samp = hdf["mah_params_samp"][:]
+        # ms_params_samp = hdf["ms_params_samp"][:]
+        # q_params_samp = hdf["q_params_samp"][:]
+        tobs_id = hdf["tobs_id"][:]
+        # tobs_val = hdf["tobs_val"][:]
+        # redshift_val = hdf["redshift_val"][:]
+
+    # Create loss_data ---------------------------------------------
+    print("Creating loss data...")
+
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    mah_params_data = []
+    logmp0_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+    smhm_targets = []
+
+    tarr_logm0 = np.logspace(-1, LGT0, 50)
+
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j)
+
+            if sel.sum() < nhalos:
+                continue
+            arange_sel = np.arange(len(tobs_id))[sel]
+            arange_sel = np.random.choice(arange_sel, nhalos, replace=False)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            smhm_targets.append(smhm[i, j])
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+    smhm_targets = np.array(smhm_targets)
+
+    ran_key_data = jran.split(ran_key, len(smhm_targets))
+    loss_data = (
+        mah_params_data,
+        logmp0_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        smhm_targets,
+    )
+
+    plot_data = (
+        age_targets,
+        logmh_binsc,
+        tobs_id,
+        logmh_id,
+        tarr_logm0,
+        lgmu_infall,
+        logmhost_infall,
+        gyr_since_infall,
+        ran_key,
+        redshift_targets,
+        smhm,
+        mah_params_samp,
+    )
+
+    return loss_data, plot_data
+
+
+def get_loss_data_pdfs_mstar(indir, nhalos):
+    # Load PDF data ---------------------------------------------
+    print("Loading PDF Mstar data...")
+
+    fname = os.path.join(indir, "smdpl_smhm.h5")
+    with h5py.File(fname, "r") as hdf:
+        redshift_targets = hdf["redshift_targets"][:]
+        smhm_diff = hdf["smhm_diff"][:]
+        smhm = hdf["smhm"][:]
+        logmh_bins = hdf["logmh_bins"][:]
+        age_targets = hdf["age_targets"][:]
+        hist = hdf["hist"][:]
+        counts = hdf["counts"][:]
+        counts_cen = hdf["counts_cen"][:]
+        counts_sat = hdf["counts_sat"][:]
+
+    logmh_binsc = 0.5 * (logmh_bins[1:] + logmh_bins[:-1])
+
+    fname = os.path.join(indir, "smdpl_smhm_samples_haloes.h5")
+    with h5py.File(fname, "r") as hdf:
+        logmh_id = hdf["logmh_id"][:]
+        logmh_val = hdf["logmh_id"][:]
+        mah_params_samp = hdf["mah_params_samp"][:]
+        ms_params_samp = hdf["ms_params_samp"][:]
+        q_params_samp = hdf["q_params_samp"][:]
+        upid_samp = hdf["upid_samp"][:]
+        tobs_id = hdf["tobs_id"][:]
+        tobs_val = hdf["tobs_val"][:]
+        redshift_val = hdf["redshift_val"][:]
+
+    fname = os.path.join(indir, "smdpl_mstar_ssfr.h5")
+    with h5py.File(fname, "r") as hdf:
+        mstar_wcounts = hdf["mstar_wcounts"][:]
+        mstar_counts = hdf["mstar_counts"][:]
+        mstar_ssfr_wcounts_cent = hdf["mstar_ssfr_wcounts_cent"][:]
+        mstar_ssfr_wcounts_sat = hdf["mstar_ssfr_wcounts_sat"][:]
+        logssfr_bins_pdf = hdf["logssfr_bins_pdf"][:]
+        logmstar_bins_pdf = hdf["logmstar_bins_pdf"][:]
+        """
+        hdfout["mstar_wcounts"] = mstar_wcounts
+        hdfout["mstar_counts"] = mstar_counts
+        hdfout["mstar_ssfr_wcounts_cent"] = mstar_ssfr_wcounts_cent
+        hdfout["mstar_ssfr_wcounts_sat"] = mstar_ssfr_wcounts_sat
+        hdfout["logmh_bins"] = smhm_utils.LOGMH_BINS
+        hdfout["logmstar_bins_pdf"] = smhm_utils.LOGMSTAR_BINS_PDF
+        hdfout["logssfr_bins_pdf"] = smhm_utils.LOGSSFR_BINS_PDF
+        hdfout["redshift_targets"] = redshift_targets
+        hdfout["age_targets"] = age_targets
+        """
+
+    logssfr_binsc_pdf = 0.5 * (logssfr_bins_pdf[1:] + logssfr_bins_pdf[:-1])
+    logmstar_binsc_pdf = 0.5 * (logmstar_bins_pdf[1:] + logmstar_bins_pdf[:-1])
+
+    # Create loss_data ---------------------------------------------
+    print("Creating loss data...")
+
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    mah_params_data = []
+    logmp0_data = []
+    upid_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+    mstar_counts_target = []
+
+    tarr_logm0 = np.logspace(-1, LGT0, 50)
+
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j)
+
+            if sel.sum() < 50:
+                continue
+            replace = True if sel.sum() < nhalos else False
+            arange_sel = np.arange(len(tobs_id))[sel]
+            arange_sel = np.random.choice(arange_sel, nhalos, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            upid_data.append(upid_samp[arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mstar_counts_target.append(mstar_wcounts[i, j] / mstar_wcounts[i, j].sum())
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+        # break
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    upid_data = np.array(upid_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+    mstar_counts_target = np.array(mstar_counts_target)
+
+    ran_key_data = jran.split(ran_key, len(mstar_counts_target))
+    loss_data_mstar = (
+        mah_params_data,
+        logmp0_data,
+        upid_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        logmstar_bins_pdf,
+        mstar_counts_target,
+    )
+
+    # Create loss_data for plot ---------------------------------------------
+    print("Creating loss data for plot...")
+    nhalos_plot = 10000
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    mah_params_data = []
+    logmp0_data = []
+    upid_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+    mstar_counts_target = []
+
+    tarr_logm0 = np.logspace(-1, LGT0, 50)
+
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j)
+
+            if sel.sum() < 50:
+                continue
+            replace = True if sel.sum() < nhalos_plot else False
+            arange_sel = np.arange(len(tobs_id))[sel]
+            arange_sel = np.random.choice(arange_sel, nhalos_plot, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            upid_data.append(upid_samp[arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mstar_counts_target.append(mstar_wcounts[i, j] / mstar_wcounts[i, j].sum())
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+        # break
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    upid_data = np.array(upid_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+    mstar_counts_target = np.array(mstar_counts_target)
+
+    ran_key_data = jran.split(ran_key, len(mstar_counts_target))
+    loss_data_mstar_pred = (
+        mah_params_data,
+        logmp0_data,
+        upid_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        logmstar_bins_pdf,
+        mstar_counts_target,
+    )
+    plot_data = (
+        logmstar_bins_pdf,
+        mstar_wcounts,
+        age_targets,
+        redshift_targets,
+        tobs_id,
+        logmh_id,
+        logmh_binsc,
+        loss_data_mstar_pred,
+    )
+
+    return loss_data_mstar, plot_data
+
+
+def get_loss_data_pdfs_ssfr_central(indir, nhalos):
+
+    print("Loading PDF Mstar data...")
+
+    fname = os.path.join(indir, "smdpl_smhm.h5")
+    with h5py.File(fname, "r") as hdf:
+        redshift_targets = hdf["redshift_targets"][:]
+        smhm_diff = hdf["smhm_diff"][:]
+        smhm = hdf["smhm"][:]
+        logmh_bins = hdf["logmh_bins"][:]
+        age_targets = hdf["age_targets"][:]
+        hist = hdf["hist"][:]
+        counts = hdf["counts"][:]
+        counts_cen = hdf["counts_cen"][:]
+        counts_sat = hdf["counts_sat"][:]
+
+    logmh_binsc = 0.5 * (logmh_bins[1:] + logmh_bins[:-1])
+
+    fname = os.path.join(indir, "smdpl_smhm_samples_haloes.h5")
+    with h5py.File(fname, "r") as hdf:
+        logmh_id = hdf["logmh_id"][:]
+        logmh_val = hdf["logmh_id"][:]
+        mah_params_samp = hdf["mah_params_samp"][:]
+        ms_params_samp = hdf["ms_params_samp"][:]
+        q_params_samp = hdf["q_params_samp"][:]
+        upid_samp = hdf["upid_samp"][:]
+        tobs_id = hdf["tobs_id"][:]
+        tobs_val = hdf["tobs_val"][:]
+        redshift_val = hdf["redshift_val"][:]
+
+    fname = os.path.join(indir, "smdpl_mstar_ssfr.h5")
+    with h5py.File(fname, "r") as hdf:
+        mstar_wcounts = hdf["mstar_wcounts"][:]
+        mstar_counts = hdf["mstar_counts"][:]
+        mstar_ssfr_wcounts_cent = hdf["mstar_ssfr_wcounts_cent"][:]
+        mstar_ssfr_wcounts_sat = hdf["mstar_ssfr_wcounts_sat"][:]
+        logssfr_bins_pdf = hdf["logssfr_bins_pdf"][:]
+        logmstar_bins_pdf = hdf["logmstar_bins_pdf"][:]
+        """
+        hdfout["mstar_wcounts"] = mstar_wcounts
+        hdfout["mstar_counts"] = mstar_counts
+        hdfout["mstar_ssfr_wcounts_cent"] = mstar_ssfr_wcounts_cent
+        hdfout["mstar_ssfr_wcounts_sat"] = mstar_ssfr_wcounts_sat
+        hdfout["logmh_bins"] = smhm_utils.LOGMH_BINS
+        hdfout["logmstar_bins_pdf"] = smhm_utils.LOGMSTAR_BINS_PDF
+        hdfout["logssfr_bins_pdf"] = smhm_utils.LOGSSFR_BINS_PDF
+        hdfout["redshift_targets"] = redshift_targets
+        hdfout["age_targets"] = age_targets
+        """
+
+    logssfr_binsc_pdf = 0.5 * (logssfr_bins_pdf[1:] + logssfr_bins_pdf[:-1])
+    logmstar_binsc_pdf = 0.5 * (logmstar_bins_pdf[1:] + logmstar_bins_pdf[:-1])
+
+    mhalo_pdf_hist = hist / np.sum(hist, axis=1)[:, None]
+    mhalo_pdf = counts / np.sum(counts, axis=1)[:, None]
+    mhalo_pdf_cen = counts_cen / np.sum(counts_cen, axis=1)[:, None]
+    mhalo_pdf_sat = counts_sat / np.sum(counts_sat, axis=1)[:, None]
+
+    # Create loss_data ---------------------------------------------
+    print("Creating loss data...")
+
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    mah_params_data = []
+    logmp0_data = []
+    upid_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+
+    mstar_ssfr_pdfs_cent = np.clip(mstar_ssfr_wcounts_cent, 0.0, None)
+    mstar_ssfr_pdfs_cent = (
+        mstar_ssfr_pdfs_cent
+        / np.sum(mstar_ssfr_pdfs_cent, axis=(2, 3))[:, :, None, None]
+    )
+    mstar_ssfr_pdfs_cent = np.where(
+        np.isnan(mstar_ssfr_pdfs_cent), 0.0, mstar_ssfr_pdfs_cent
+    )
+    mstar_ssfr_pdfs_cent = np.einsum(
+        "zmab,zm->zab", mstar_ssfr_pdfs_cent, mhalo_pdf_cen
+    )
+
+    tarr_logm0 = np.logspace(-1, LGT0, 50)
+
+    index_mhalo = []
+    indx_pdf = []
+    _run_indx = 0
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+        index_mhalo_atz = []
+        indx_pdf_atz = []
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j) & (upid_samp == -1)
+
+            if sel.sum() < 50:
+                print(i, j)
+                continue
+            arange_sel = np.arange(len(tobs_id))[sel]
+            replace = True if sel.sum() < nhalos else False
+            arange_sel = np.random.choice(arange_sel, nhalos, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            upid_data.append(upid_samp[arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+
+            index_mhalo_atz.append(j)
+            indx_pdf_atz.append(_run_indx)
+            _run_indx += 1
+
+        index_mhalo.append(np.array(index_mhalo_atz))
+        indx_pdf.append(np.array(indx_pdf_atz))
+        # break
+    # target_mstar_ids = np.array([4, 9, 14, 17, 19, 22])
+    target_mstar_ids = np.array([9, 14, 17, 19, 22])
+    # target_mstar_ids = np.array([14, 17, 19, 22])
+    print(logmstar_binsc_pdf[target_mstar_ids])
+    target_data = np.zeros((5, len(target_mstar_ids), len(logssfr_binsc_pdf)))
+    for i in range(len(age_targets)):
+        for j, jval in enumerate(target_mstar_ids):
+            target_data[i, j] = (
+                mstar_ssfr_pdfs_cent[i, jval] / mstar_ssfr_pdfs_cent[i, jval].sum()
+            )
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    upid_data = np.array(upid_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+
+    ran_key_data = jran.split(ran_key, len(t_obs_targets))
+
+    ndbins_lo = []
+    ndbins_hi = []
+    for i in range(len(logmstar_bins_pdf) - 1):
+        for j in range(len(logssfr_bins_pdf) - 1):
+            ndbins_lo.append([logmstar_bins_pdf[i], logssfr_bins_pdf[j]])
+            ndbins_hi.append([logmstar_bins_pdf[i + 1], logssfr_bins_pdf[j + 1]])
+    ndbins_lo = np.array(ndbins_lo)
+    ndbins_hi = np.array(ndbins_hi)
+
+    loss_data_ssfr = (
+        mah_params_data,
+        logmp0_data,
+        upid_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        ndbins_lo,
+        ndbins_hi,
+        logmstar_bins_pdf,
+        logssfr_bins_pdf,
+        mhalo_pdf_cen,
+        index_mhalo,
+        indx_pdf,
+        target_mstar_ids,
+        target_data,
+    )
+
+    # Create loss_data for plot ---------------------------------------------
+    print("Creating loss data for plot...")
+    nhalos_plot = 10000
+
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    mah_params_data = []
+    logmp0_data = []
+    upid_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+
+    mstar_ssfr_pdfs_cent = np.clip(mstar_ssfr_wcounts_cent, 0.0, None)
+    mstar_ssfr_pdfs_cent = (
+        mstar_ssfr_pdfs_cent
+        / np.sum(mstar_ssfr_pdfs_cent, axis=(2, 3))[:, :, None, None]
+    )
+    mstar_ssfr_pdfs_cent = np.where(
+        np.isnan(mstar_ssfr_pdfs_cent), 0.0, mstar_ssfr_pdfs_cent
+    )
+    mstar_ssfr_pdfs_cent = np.einsum(
+        "zmab,zm->zab", mstar_ssfr_pdfs_cent, mhalo_pdf_cen
+    )
+
+    index_mhalo = []
+    indx_pdf = []
+    _run_indx = 0
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+        index_mhalo_atz = []
+        indx_pdf_atz = []
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j) & (upid_samp == -1)
+
+            if sel.sum() < 50:
+                print(i, j)
+                continue
+            arange_sel = np.arange(len(tobs_id))[sel]
+            replace = True if sel.sum() < nhalos_plot else False
+            arange_sel = np.random.choice(arange_sel, nhalos_plot, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            upid_data.append(upid_samp[arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+
+            index_mhalo_atz.append(j)
+            indx_pdf_atz.append(_run_indx)
+            _run_indx += 1
+
+        index_mhalo.append(np.array(index_mhalo_atz))
+        indx_pdf.append(np.array(indx_pdf_atz))
+        # break
+    # target_mstar_ids = np.array([4, 9, 14, 17, 19, 22])
+    target_mstar_ids = np.array([9, 14, 17, 19, 22])
+    # target_mstar_ids = np.array([14, 17, 19, 22])
+    print(logmstar_binsc_pdf[target_mstar_ids])
+    target_data = np.zeros((5, len(target_mstar_ids), len(logssfr_binsc_pdf)))
+    for i in range(len(age_targets)):
+        for j, jval in enumerate(target_mstar_ids):
+            target_data[i, j] = (
+                mstar_ssfr_pdfs_cent[i, jval] / mstar_ssfr_pdfs_cent[i, jval].sum()
+            )
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    upid_data = np.array(upid_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+
+    ran_key_data = jran.split(ran_key, len(t_obs_targets))
+
+    ndbins_lo = []
+    ndbins_hi = []
+    for i in range(len(logmstar_bins_pdf) - 1):
+        for j in range(len(logssfr_bins_pdf) - 1):
+            ndbins_lo.append([logmstar_bins_pdf[i], logssfr_bins_pdf[j]])
+            ndbins_hi.append([logmstar_bins_pdf[i + 1], logssfr_bins_pdf[j + 1]])
+    ndbins_lo = np.array(ndbins_lo)
+    ndbins_hi = np.array(ndbins_hi)
+
+    loss_data_ssfr_pred = (
+        mah_params_data,
+        logmp0_data,
+        upid_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        ndbins_lo,
+        ndbins_hi,
+        logmstar_bins_pdf,
+        logssfr_bins_pdf,
+        mhalo_pdf_cen,
+        index_mhalo,
+        indx_pdf,
+        target_mstar_ids,
+        target_data,
+    )
+
+    plot_data = (
+        target_mstar_ids,
+        logssfr_binsc_pdf,
+        target_data,
+        loss_data_ssfr_pred,
+    )
+
+    return loss_data_ssfr, plot_data
+
+
+def get_loss_data_pdfs_ssfr_satellite(indir, nhalos):
+
+    print("Loading PDF Mstar data...")
+
+    fname = os.path.join(indir, "smdpl_smhm.h5")
+    with h5py.File(fname, "r") as hdf:
+        redshift_targets = hdf["redshift_targets"][:]
+        smhm_diff = hdf["smhm_diff"][:]
+        smhm = hdf["smhm"][:]
+        logmh_bins = hdf["logmh_bins"][:]
+        age_targets = hdf["age_targets"][:]
+        hist = hdf["hist"][:]
+        counts = hdf["counts"][:]
+        counts_cen = hdf["counts_cen"][:]
+        counts_sat = hdf["counts_sat"][:]
+
+    logmh_binsc = 0.5 * (logmh_bins[1:] + logmh_bins[:-1])
+
+    fname = os.path.join(indir, "smdpl_smhm_samples_haloes.h5")
+    with h5py.File(fname, "r") as hdf:
+        logmh_id = hdf["logmh_id"][:]
+        logmh_val = hdf["logmh_id"][:]
+        mah_params_samp = hdf["mah_params_samp"][:]
+        ms_params_samp = hdf["ms_params_samp"][:]
+        q_params_samp = hdf["q_params_samp"][:]
+        upid_samp = hdf["upid_samp"][:]
+        tobs_id = hdf["tobs_id"][:]
+        tobs_val = hdf["tobs_val"][:]
+        redshift_val = hdf["redshift_val"][:]
+
+    fname = os.path.join(indir, "smdpl_mstar_ssfr.h5")
+    with h5py.File(fname, "r") as hdf:
+        mstar_wcounts = hdf["mstar_wcounts"][:]
+        mstar_counts = hdf["mstar_counts"][:]
+        mstar_ssfr_wcounts_cent = hdf["mstar_ssfr_wcounts_cent"][:]
+        mstar_ssfr_wcounts_sat = hdf["mstar_ssfr_wcounts_sat"][:]
+        logssfr_bins_pdf = hdf["logssfr_bins_pdf"][:]
+        logmstar_bins_pdf = hdf["logmstar_bins_pdf"][:]
+        """
+        hdfout["mstar_wcounts"] = mstar_wcounts
+        hdfout["mstar_counts"] = mstar_counts
+        hdfout["mstar_ssfr_wcounts_cent"] = mstar_ssfr_wcounts_cent
+        hdfout["mstar_ssfr_wcounts_sat"] = mstar_ssfr_wcounts_sat
+        hdfout["logmh_bins"] = smhm_utils.LOGMH_BINS
+        hdfout["logmstar_bins_pdf"] = smhm_utils.LOGMSTAR_BINS_PDF
+        hdfout["logssfr_bins_pdf"] = smhm_utils.LOGSSFR_BINS_PDF
+        hdfout["redshift_targets"] = redshift_targets
+        hdfout["age_targets"] = age_targets
+        """
+
+    logssfr_binsc_pdf = 0.5 * (logssfr_bins_pdf[1:] + logssfr_bins_pdf[:-1])
+    logmstar_binsc_pdf = 0.5 * (logmstar_bins_pdf[1:] + logmstar_bins_pdf[:-1])
+
+    mhalo_pdf_hist = hist / np.sum(hist, axis=1)[:, None]
+    mhalo_pdf = counts / np.sum(counts, axis=1)[:, None]
+    mhalo_pdf_cen = counts_cen / np.sum(counts_cen, axis=1)[:, None]
+    mhalo_pdf_sat = counts_sat / np.sum(counts_sat, axis=1)[:, None]
+
+    # Create loss_data ---------------------------------------------
+    print("Creating loss data...")
+
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    mah_params_data = []
+    logmp0_data = []
+    upid_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+
+    mstar_ssfr_pdfs_sat = np.clip(mstar_ssfr_wcounts_sat, 0.0, None)
+    mstar_ssfr_pdfs_sat = (
+        mstar_ssfr_pdfs_sat / np.sum(mstar_ssfr_pdfs_sat, axis=(2, 3))[:, :, None, None]
+    )
+    mstar_ssfr_pdfs_sat = np.where(
+        np.isnan(mstar_ssfr_pdfs_sat), 0.0, mstar_ssfr_pdfs_sat
+    )
+    mstar_ssfr_pdfs_sat = np.einsum("zmab,zm->zab", mstar_ssfr_pdfs_sat, mhalo_pdf_sat)
+
+    index_mhalo = []
+    indx_pdf = []
+    _run_indx = 0
+
+    tarr_logm0 = np.logspace(-1, LGT0, 50)
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+        index_mhalo_atz = []
+        indx_pdf_atz = []
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j) & (upid_samp != -1)
+
+            if sel.sum() < 50:
+                print(i, j)
+                continue
+            arange_sel = np.arange(len(tobs_id))[sel]
+            replace = True if sel.sum() < nhalos else False
+            arange_sel = np.random.choice(arange_sel, nhalos, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            upid_data.append(upid_samp[arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+
+            index_mhalo_atz.append(j)
+            indx_pdf_atz.append(_run_indx)
+            _run_indx += 1
+
+        index_mhalo.append(np.array(index_mhalo_atz))
+        indx_pdf.append(np.array(indx_pdf_atz))
+
+        # break
+    # target_mstar_ids = np.array([4, 9, 14, 17, 19, 22])
+    target_mstar_ids = np.array([9, 14, 17, 19, 22])
+    # target_mstar_ids = np.array([14, 17, 19, 22])
+    print(logmstar_binsc_pdf[target_mstar_ids])
+    target_data_sat = np.zeros((5, len(target_mstar_ids), len(logssfr_binsc_pdf)))
+    for i in range(len(age_targets)):
+        for j, jval in enumerate(target_mstar_ids):
+            target_data_sat[i, j] = (
+                mstar_ssfr_pdfs_sat[i, jval] / mstar_ssfr_pdfs_sat[i, jval].sum()
+            )
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    upid_data = np.array(upid_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+
+    ran_key_data = jran.split(ran_key, len(t_obs_targets))
+
+    ndbins_lo = []
+    ndbins_hi = []
+    for i in range(len(logmstar_bins_pdf) - 1):
+        for j in range(len(logssfr_bins_pdf) - 1):
+            ndbins_lo.append([logmstar_bins_pdf[i], logssfr_bins_pdf[j]])
+            ndbins_hi.append([logmstar_bins_pdf[i + 1], logssfr_bins_pdf[j + 1]])
+    ndbins_lo = np.array(ndbins_lo)
+    ndbins_hi = np.array(ndbins_hi)
+
+    loss_data_ssfr_sat = (
+        mah_params_data,
+        logmp0_data,
+        upid_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        ndbins_lo,
+        ndbins_hi,
+        logmstar_bins_pdf,
+        logssfr_bins_pdf,
+        mhalo_pdf_sat,
+        index_mhalo,
+        indx_pdf,
+        target_mstar_ids,
+        target_data_sat,
+    )
+
+    # Create loss_data for plot ---------------------------------------------
+    print("Creating loss data for plot...")
+    nhalos_plot = 10000
+
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    mah_params_data = []
+    logmp0_data = []
+    upid_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+
+    mstar_ssfr_pdfs_sat = np.clip(mstar_ssfr_wcounts_sat, 0.0, None)
+    mstar_ssfr_pdfs_sat = (
+        mstar_ssfr_pdfs_sat / np.sum(mstar_ssfr_pdfs_sat, axis=(2, 3))[:, :, None, None]
+    )
+    mstar_ssfr_pdfs_sat = np.where(
+        np.isnan(mstar_ssfr_pdfs_sat), 0.0, mstar_ssfr_pdfs_sat
+    )
+    mstar_ssfr_pdfs_sat = np.einsum("zmab,zm->zab", mstar_ssfr_pdfs_sat, mhalo_pdf_sat)
+
+    index_mhalo = []
+    indx_pdf = []
+    _run_indx = 0
+
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+        index_mhalo_atz = []
+        indx_pdf_atz = []
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j) & (upid_samp != -1)
+
+            if sel.sum() < 50:
+                print(i, j)
+                continue
+            arange_sel = np.arange(len(tobs_id))[sel]
+            replace = True if sel.sum() < nhalos_plot else False
+            arange_sel = np.random.choice(arange_sel, nhalos_plot, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            upid_data.append(upid_samp[arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+
+            index_mhalo_atz.append(j)
+            indx_pdf_atz.append(_run_indx)
+            _run_indx += 1
+
+        index_mhalo.append(np.array(index_mhalo_atz))
+        indx_pdf.append(np.array(indx_pdf_atz))
+        # break
+    # target_mstar_ids = np.array([4, 9, 14, 17, 19, 22])
+    target_mstar_ids = np.array([9, 14, 17, 19, 22])
+    # target_mstar_ids = np.array([14, 17, 19, 22])
+    print(logmstar_binsc_pdf[target_mstar_ids])
+    target_data_sat = np.zeros((5, len(target_mstar_ids), len(logssfr_binsc_pdf)))
+    for i in range(len(age_targets)):
+        for j, jval in enumerate(target_mstar_ids):
+            target_data_sat[i, j] = (
+                mstar_ssfr_pdfs_sat[i, jval] / mstar_ssfr_pdfs_sat[i, jval].sum()
+            )
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    upid_data = np.array(upid_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+
+    ran_key_data = jran.split(ran_key, len(t_obs_targets))
+
+    ndbins_lo = []
+    ndbins_hi = []
+    for i in range(len(logmstar_bins_pdf) - 1):
+        for j in range(len(logssfr_bins_pdf) - 1):
+            ndbins_lo.append([logmstar_bins_pdf[i], logssfr_bins_pdf[j]])
+            ndbins_hi.append([logmstar_bins_pdf[i + 1], logssfr_bins_pdf[j + 1]])
+    ndbins_lo = np.array(ndbins_lo)
+    ndbins_hi = np.array(ndbins_hi)
+
+    loss_data_ssfr_sat_pred = (
+        mah_params_data,
+        logmp0_data,
+        upid_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        ndbins_lo,
+        ndbins_hi,
+        logmstar_bins_pdf,
+        logssfr_bins_pdf,
+        mhalo_pdf_sat,
+        index_mhalo,
+        indx_pdf,
+        target_mstar_ids,
+        target_data_sat,
+    )
+
+    plot_data = (
+        target_mstar_ids,
+        logssfr_binsc_pdf,
+        target_data_sat,
+        loss_data_ssfr_sat_pred,
+    )
+
+    return loss_data_ssfr_sat, plot_data
+
+
+def get_loss_data_pdfs_mstar_cen(indir, nhalos):
+    # Load PDF data ---------------------------------------------
+    print("Loading PDF Mstar for centrals data...")
+
+    fname = os.path.join(indir, "smdpl_smhm.h5")
+    with h5py.File(fname, "r") as hdf:
+        redshift_targets = hdf["redshift_targets"][:]
+        smhm_diff = hdf["smhm_diff"][:]
+        smhm = hdf["smhm"][:]
+        logmh_bins = hdf["logmh_bins"][:]
+        age_targets = hdf["age_targets"][:]
+        hist = hdf["hist"][:]
+        counts = hdf["counts"][:]
+        counts_cen = hdf["counts_cen"][:]
+        counts_sat = hdf["counts_sat"][:]
+
+    logmh_binsc = 0.5 * (logmh_bins[1:] + logmh_bins[:-1])
+
+    fname = os.path.join(indir, "smdpl_smhm_samples_haloes.h5")
+    with h5py.File(fname, "r") as hdf:
+        logmh_id = hdf["logmh_id"][:]
+        logmh_val = hdf["logmh_id"][:]
+        mah_params_samp = hdf["mah_params_samp"][:]
+        ms_params_samp = hdf["ms_params_samp"][:]
+        q_params_samp = hdf["q_params_samp"][:]
+        upid_samp = hdf["upid_samp"][:]
+        tobs_id = hdf["tobs_id"][:]
+        tobs_val = hdf["tobs_val"][:]
+        redshift_val = hdf["redshift_val"][:]
+
+    fname = os.path.join(indir, "smdpl_mstar_ssfr.h5")
+    with h5py.File(fname, "r") as hdf:
+        mstar_wcounts = hdf["mstar_wcounts"][:]
+        mstar_counts = hdf["mstar_counts"][:]
+        mstar_ssfr_wcounts_cent = hdf["mstar_ssfr_wcounts_cent"][:]
+        mstar_ssfr_wcounts_sat = hdf["mstar_ssfr_wcounts_sat"][:]
+        logssfr_bins_pdf = hdf["logssfr_bins_pdf"][:]
+        logmstar_bins_pdf = hdf["logmstar_bins_pdf"][:]
+        """
+        hdfout["mstar_wcounts"] = mstar_wcounts
+        hdfout["mstar_counts"] = mstar_counts
+        hdfout["mstar_ssfr_wcounts_cent"] = mstar_ssfr_wcounts_cent
+        hdfout["mstar_ssfr_wcounts_sat"] = mstar_ssfr_wcounts_sat
+        hdfout["logmh_bins"] = smhm_utils.LOGMH_BINS
+        hdfout["logmstar_bins_pdf"] = smhm_utils.LOGMSTAR_BINS_PDF
+        hdfout["logssfr_bins_pdf"] = smhm_utils.LOGSSFR_BINS_PDF
+        hdfout["redshift_targets"] = redshift_targets
+        hdfout["age_targets"] = age_targets
+        """
+
+    mstar_wcounts_cen = np.sum(mstar_ssfr_wcounts_cent, axis=3)
+    mstar_wcounts_sat = np.sum(mstar_ssfr_wcounts_sat, axis=3)
+
+    logssfr_binsc_pdf = 0.5 * (logssfr_bins_pdf[1:] + logssfr_bins_pdf[:-1])
+    logmstar_binsc_pdf = 0.5 * (logmstar_bins_pdf[1:] + logmstar_bins_pdf[:-1])
+
+    # Create loss_data ---------------------------------------------
+    print("Creating loss data...")
+
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    # Centrals
+    mah_params_data = []
+    logmp0_data = []
+    upid_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+    mstar_counts_target = []
+
+    tarr_logm0 = np.logspace(-1, LGT0, 50)
+
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j) & (upid_samp == -1)
+
+            if sel.sum() < 50:
+                continue
+            replace = True if sel.sum() < nhalos else False
+            arange_sel = np.arange(len(tobs_id))[sel]
+            arange_sel = np.random.choice(arange_sel, nhalos, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            upid_data.append(upid_samp[arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mstar_counts_target.append(
+                mstar_wcounts_cen[i, j] / mstar_wcounts_cen[i, j].sum()
+            )
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+        # break
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    upid_data = np.array(upid_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+    mstar_counts_target = np.array(mstar_counts_target)
+
+    ran_key_data = jran.split(ran_key, len(mstar_counts_target))
+    loss_data_mstar = (
+        mah_params_data,
+        logmp0_data,
+        upid_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        logmstar_bins_pdf,
+        mstar_counts_target,
+    )
+
+    # Create loss_data for plot ---------------------------------------------
+    print("Creating loss data for plot...")
+    nhalos_plot = 10000
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    mah_params_data = []
+    logmp0_data = []
+    upid_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+    mstar_counts_target = []
+
+    tarr_logm0 = np.logspace(-1, LGT0, 50)
+
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j) & (upid_samp == -1)
+
+            if sel.sum() < 50:
+                continue
+            replace = True if sel.sum() < nhalos_plot else False
+            arange_sel = np.arange(len(tobs_id))[sel]
+            arange_sel = np.random.choice(arange_sel, nhalos_plot, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            upid_data.append(upid_samp[arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mstar_counts_target.append(
+                mstar_wcounts_cen[i, j] / mstar_wcounts_cen[i, j].sum()
+            )
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+        # break
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    upid_data = np.array(upid_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+    mstar_counts_target = np.array(mstar_counts_target)
+
+    ran_key_data = jran.split(ran_key, len(mstar_counts_target))
+    loss_data_mstar_pred = (
+        mah_params_data,
+        logmp0_data,
+        upid_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        logmstar_bins_pdf,
+        mstar_counts_target,
+    )
+    plot_data = (
+        logmstar_bins_pdf,
+        mstar_wcounts,
+        age_targets,
+        redshift_targets,
+        tobs_id,
+        logmh_id,
+        logmh_binsc,
+        loss_data_mstar_pred,
+    )
+
+    return loss_data_mstar, plot_data
+
+
+def get_loss_data_pdfs_mstar_sat(indir, nhalos):
+    # Load PDF data ---------------------------------------------
+    print("Loading PDF Mstar for satellites data...")
+
+    fname = os.path.join(indir, "smdpl_smhm.h5")
+    with h5py.File(fname, "r") as hdf:
+        redshift_targets = hdf["redshift_targets"][:]
+        smhm_diff = hdf["smhm_diff"][:]
+        smhm = hdf["smhm"][:]
+        logmh_bins = hdf["logmh_bins"][:]
+        age_targets = hdf["age_targets"][:]
+        hist = hdf["hist"][:]
+        counts = hdf["counts"][:]
+        counts_cen = hdf["counts_cen"][:]
+        counts_sat = hdf["counts_sat"][:]
+
+    logmh_binsc = 0.5 * (logmh_bins[1:] + logmh_bins[:-1])
+
+    fname = os.path.join(indir, "smdpl_smhm_samples_haloes.h5")
+    with h5py.File(fname, "r") as hdf:
+        logmh_id = hdf["logmh_id"][:]
+        logmh_val = hdf["logmh_id"][:]
+        mah_params_samp = hdf["mah_params_samp"][:]
+        ms_params_samp = hdf["ms_params_samp"][:]
+        q_params_samp = hdf["q_params_samp"][:]
+        upid_samp = hdf["upid_samp"][:]
+        tobs_id = hdf["tobs_id"][:]
+        tobs_val = hdf["tobs_val"][:]
+        redshift_val = hdf["redshift_val"][:]
+
+    fname = os.path.join(indir, "smdpl_mstar_ssfr.h5")
+    with h5py.File(fname, "r") as hdf:
+        mstar_wcounts = hdf["mstar_wcounts"][:]
+        mstar_counts = hdf["mstar_counts"][:]
+        mstar_ssfr_wcounts_cent = hdf["mstar_ssfr_wcounts_cent"][:]
+        mstar_ssfr_wcounts_sat = hdf["mstar_ssfr_wcounts_sat"][:]
+        logssfr_bins_pdf = hdf["logssfr_bins_pdf"][:]
+        logmstar_bins_pdf = hdf["logmstar_bins_pdf"][:]
+        """
+        hdfout["mstar_wcounts"] = mstar_wcounts
+        hdfout["mstar_counts"] = mstar_counts
+        hdfout["mstar_ssfr_wcounts_cent"] = mstar_ssfr_wcounts_cent
+        hdfout["mstar_ssfr_wcounts_sat"] = mstar_ssfr_wcounts_sat
+        hdfout["logmh_bins"] = smhm_utils.LOGMH_BINS
+        hdfout["logmstar_bins_pdf"] = smhm_utils.LOGMSTAR_BINS_PDF
+        hdfout["logssfr_bins_pdf"] = smhm_utils.LOGSSFR_BINS_PDF
+        hdfout["redshift_targets"] = redshift_targets
+        hdfout["age_targets"] = age_targets
+        """
+
+    mstar_wcounts_cen = np.sum(mstar_ssfr_wcounts_cent, axis=3)
+    mstar_wcounts_sat = np.sum(mstar_ssfr_wcounts_sat, axis=3)
+
+    logssfr_binsc_pdf = 0.5 * (logssfr_bins_pdf[1:] + logssfr_bins_pdf[:-1])
+    logmstar_binsc_pdf = 0.5 * (logmstar_bins_pdf[1:] + logmstar_bins_pdf[:-1])
+
+    # Create loss_data ---------------------------------------------
+    print("Creating loss data...")
+
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    # Centrals
+    mah_params_data = []
+    logmp0_data = []
+    upid_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+    mstar_counts_target = []
+
+    tarr_logm0 = np.logspace(-1, LGT0, 50)
+
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j) & (upid_samp != -1)
+
+            if sel.sum() < 50:
+                continue
+            replace = True if sel.sum() < nhalos else False
+            arange_sel = np.arange(len(tobs_id))[sel]
+            arange_sel = np.random.choice(arange_sel, nhalos, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            upid_data.append(upid_samp[arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mstar_counts_target.append(
+                mstar_wcounts_sat[i, j] / mstar_wcounts_sat[i, j].sum()
+            )
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+        # break
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    upid_data = np.array(upid_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+    mstar_counts_target = np.array(mstar_counts_target)
+
+    ran_key_data = jran.split(ran_key, len(mstar_counts_target))
+    loss_data_mstar = (
+        mah_params_data,
+        logmp0_data,
+        upid_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        logmstar_bins_pdf,
+        mstar_counts_target,
+    )
+
+    # Create loss_data for plot ---------------------------------------------
+    print("Creating loss data for plot...")
+    nhalos_plot = 10000
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    lgmu_infall = -1.0
+    logmhost_infall = 13.0
+    gyr_since_infall = -99.0  # 2.0
+
+    mah_params_data = []
+    logmp0_data = []
+    upid_data = []
+    lgmu_infall_data = []
+    logmhost_infall_data = []
+    gyr_since_infall_data = []
+    t_obs_targets = []
+    mstar_counts_target = []
+
+    tarr_logm0 = np.logspace(-1, LGT0, 50)
+
+    for i in range(len(age_targets)):
+        t_target = age_targets[i]
+
+        for j in range(len(logmh_binsc)):
+            sel = (tobs_id == i) & (logmh_id == j) & (upid_samp != -1)
+
+            if sel.sum() < 50:
+                continue
+            replace = True if sel.sum() < nhalos_plot else False
+            arange_sel = np.arange(len(tobs_id))[sel]
+            arange_sel = np.random.choice(arange_sel, nhalos_plot, replace=replace)
+            mah_params_data.append(mah_params_samp[:, arange_sel])
+            upid_data.append(upid_samp[arange_sel])
+            lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
+            logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
+            gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
+            t_obs_targets.append(t_target)
+            mstar_counts_target.append(
+                mstar_wcounts_sat[i, j] / mstar_wcounts_sat[i, j].sum()
+            )
+            mah_pars_ntuple = DiffmahParams(*mah_params_samp[:, arange_sel])
+            dmhdt_fit, log_mah_fit = mah_halopop(mah_pars_ntuple, tarr_logm0, LGT0)
+            logmp0_data.append(log_mah_fit[:, -1])
+        # break
+
+    mah_params_data = np.array(mah_params_data)
+    logmp0_data = np.array(logmp0_data)
+    upid_data = np.array(upid_data)
+    lgmu_infall_data = np.array(lgmu_infall_data)
+    logmhost_infall_data = np.array(logmhost_infall_data)
+    gyr_since_infall_data = np.array(gyr_since_infall_data)
+    t_obs_targets = np.array(t_obs_targets)
+    mstar_counts_target = np.array(mstar_counts_target)
+
+    ran_key_data = jran.split(ran_key, len(mstar_counts_target))
+    loss_data_mstar_pred = (
+        mah_params_data,
+        logmp0_data,
+        upid_data,
+        lgmu_infall_data,
+        logmhost_infall_data,
+        gyr_since_infall_data,
+        ran_key_data,
+        t_obs_targets,
+        logmstar_bins_pdf,
+        mstar_counts_target,
+    )
+    plot_data = (
+        logmstar_bins_pdf,
+        mstar_wcounts,
+        age_targets,
+        redshift_targets,
+        tobs_id,
+        logmh_id,
+        logmh_binsc,
+        loss_data_mstar_pred,
+    )
+
+    return loss_data_mstar, plot_data

--- a/scripts/fit_get_loss_helpers_satfrac.py
+++ b/scripts/fit_get_loss_helpers_satfrac.py
@@ -36,6 +36,7 @@ def get_loss_data_smhm(indir, nhalos):
         logmh_id = hdf["logmh_id"][:]
         # logmh_val = hdf["logmh_id"][:]
         mah_params_samp = hdf["mah_params_samp"][:]
+        upid_samp = hdf["upid_samp"][:]
         # ms_params_samp = hdf["ms_params_samp"][:]
         # q_params_samp = hdf["q_params_samp"][:]
         tobs_id = hdf["tobs_id"][:]
@@ -53,6 +54,7 @@ def get_loss_data_smhm(indir, nhalos):
 
     mah_params_data = []
     logmp0_data = []
+    upid_data = []
     lgmu_infall_data = []
     logmhost_infall_data = []
     gyr_since_infall_data = []
@@ -72,6 +74,7 @@ def get_loss_data_smhm(indir, nhalos):
             arange_sel = np.arange(len(tobs_id))[sel]
             arange_sel = np.random.choice(arange_sel, nhalos, replace=False)
             mah_params_data.append(mah_params_samp[:, arange_sel])
+            upid_data.append(upid_samp[arange_sel])
             lgmu_infall_data.append(np.ones(len(arange_sel)) * lgmu_infall)
             logmhost_infall_data.append(np.ones(len(arange_sel)) * logmhost_infall)
             gyr_since_infall_data.append(np.ones(len(arange_sel)) * gyr_since_infall)
@@ -83,6 +86,7 @@ def get_loss_data_smhm(indir, nhalos):
 
     mah_params_data = np.array(mah_params_data)
     logmp0_data = np.array(logmp0_data)
+    upid_data = np.array(upid_data)
     lgmu_infall_data = np.array(lgmu_infall_data)
     logmhost_infall_data = np.array(logmhost_infall_data)
     gyr_since_infall_data = np.array(gyr_since_infall_data)
@@ -114,6 +118,7 @@ def get_loss_data_smhm(indir, nhalos):
         redshift_targets,
         smhm,
         mah_params_samp,
+        upid_samp,
     )
 
     return loss_data, plot_data

--- a/scripts/fit_mstar_ssfr_pdfs_satfrac.py
+++ b/scripts/fit_mstar_ssfr_pdfs_satfrac.py
@@ -1,0 +1,213 @@
+import os
+import h5py
+import numpy as np
+from jax import (
+    numpy as jnp,
+    jit as jjit,
+    random as jran,
+    grad,
+    vmap,
+)
+import argparse
+from time import time
+from scipy.optimize import minimize
+from jax.example_libraries import optimizers as jax_opt
+
+from collections import OrderedDict, namedtuple
+
+from diffstar.defaults import TODAY, LGT0
+from diffmah.diffmah_kernels import mah_halopop
+
+from diffstarpop.loss_kernels.mstar_ssfr_loss_tpeak_satfrac import (
+    loss_mstar_kern_tobs_grad_wrapper,
+    loss_mstar_ssfr_kern_tobs_grad_wrapper,
+    loss_combined_wrapper,
+    loss_combined_3loss_wrapper,
+)
+
+from diffstarpop.loss_kernels.namedtuple_utils_tpeak_satfrac import (
+    tuple_to_array,
+    register_tuple_new_diffstarpop_tpeak,
+    array_to_tuple_new_diffstarpop_tpeak,
+)
+from diffstarpop.kernels.defaults_tpeak_line_satfrac import (
+    DEFAULT_DIFFSTARPOP_U_PARAMS,
+    DEFAULT_DIFFSTARPOP_PARAMS,
+    get_bounded_diffstarpop_params,
+)
+
+from fit_get_loss_helpers_satfrac import (
+    get_loss_data_pdfs_mstar,
+    get_loss_data_pdfs_ssfr_central,
+    get_loss_data_pdfs_ssfr_satellite,
+)
+
+
+BEBOP_SMHM_MEAN_DATA = "/lcrc/project/halotools/alarcon/results/"
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-indir", help="input drn", type=str, default=BEBOP_SMHM_MEAN_DATA
+    )
+    parser.add_argument(
+        "-outdir", help="output drn", type=str, default=BEBOP_SMHM_MEAN_DATA
+    )
+    parser.add_argument(
+        "-nhalos", help="Number of halos for fitting", type=int, default=100
+    )
+    parser.add_argument(
+        "-nstep", help="Number of steps for fitting", type=int, default=1000
+    )
+    parser.add_argument(
+        "-outname",
+        help="output fname for best params",
+        type=str,
+        default="bestfit_diffstarpop_params",
+    )
+    parser.add_argument(
+        "-loss_type",
+        help="Which data to target",
+        type=str,
+        choices=["mstar", "mstar_ssfr_cen", "mstar_ssfr_cen_sat"],
+        default="mstar",
+    )
+    parser.add_argument(
+        "--params_path",
+        type=str,
+        default=None,
+        help="Path were diffstarpop params are stored",
+    )
+    parser.add_argument(
+        "--print_loss",
+        type=int,
+        default=100,
+        help="How many steps before printing current loss",
+    )
+
+    args = parser.parse_args()
+    indir = args.indir
+    outdir = args.outdir
+    nhalos = args.nhalos
+    n_step = args.nstep
+    outname = args.outname
+    params_path = args.params_path
+    loss_type = args.loss_type
+
+    # Load MStar pdf data ---------------------------------------------
+
+    if loss_type == "mstar":
+        loss_data_mstar, plot_data_mstar = get_loss_data_pdfs_mstar(indir, nhalos)
+        loss_data = (loss_data_mstar,)
+    elif loss_type == "mstar_ssfr_cen":
+        loss_data_mstar, plot_data_mstar = get_loss_data_pdfs_mstar(indir, nhalos)
+        loss_data_ssfr_cen, plot_data_ssfr_cen = get_loss_data_pdfs_ssfr_central(
+            indir, nhalos
+        )
+        loss_data = (loss_data_mstar, loss_data_ssfr_cen)
+    elif loss_type == "mstar_ssfr_cen_sat":
+        loss_data_mstar, plot_data_mstar = get_loss_data_pdfs_mstar(indir, nhalos)
+        loss_data_ssfr_cen, plot_data_ssfr_cen = get_loss_data_pdfs_ssfr_central(
+            indir, nhalos
+        )
+        loss_data_ssfr_sat, plot_data_ssfr_sat = get_loss_data_pdfs_ssfr_satellite(
+            indir, nhalos
+        )
+        loss_data = (loss_data_mstar, loss_data_ssfr_cen, loss_data_ssfr_sat)
+
+    # Define loss kernel ---------------------------------------------
+    if loss_type == "mstar":
+        loss_kernel = loss_mstar_kern_tobs_grad_wrapper
+    elif loss_type == "mstar_ssfr_cen":
+        loss_kernel = loss_combined_wrapper
+    elif loss_type == "mstar_ssfr_cen_sat":
+        loss_kernel = loss_combined_3loss_wrapper
+
+    # Register params ---------------------------------------------
+
+    unbound_params_dict = OrderedDict(diffstarpop_u_params=DEFAULT_DIFFSTARPOP_U_PARAMS)
+    UnboundParams = namedtuple("UnboundParams", list(unbound_params_dict.keys()))
+    register_tuple_new_diffstarpop_tpeak(UnboundParams)
+
+    if params_path is None:
+        all_u_params = tuple_to_array(DEFAULT_DIFFSTARPOP_U_PARAMS)
+    else:
+        params = np.load(params_path)
+        all_u_params = params["diffstarpop_u_params"]
+
+    # Run fitter ---------------------------------------------
+    print("Running fitter...")
+
+    params_init = tuple_to_array(all_u_params)
+    loss_kernel(params_init, *loss_data)
+
+    start = time()
+
+    step_size = 0.01
+
+    loss_arr = np.zeros(n_step).astype("f4") + np.inf
+
+    opt_init, opt_update, get_params = jax_opt.adam(step_size)
+    opt_state = opt_init(params_init)
+
+    n_params = len(params_init)
+    params_arr = np.zeros((n_step, n_params)).astype("f4")
+
+    n_mah = 100
+
+    ran_key = jran.PRNGKey(np.random.randint(2**32))
+
+    no_nan_grads_arr = np.zeros(n_step)
+    for istep in range(n_step):
+        start = time()
+        ran_key, subkey = jran.split(ran_key, 2)
+
+        p = np.array(get_params(opt_state))
+
+        loss, grads = loss_kernel(p, *loss_data)
+
+        no_nan_params = np.all(np.isfinite(p))
+        no_nan_loss = np.isfinite(loss)
+        no_nan_grads = np.all(np.isfinite(grads))
+        if ~no_nan_params | ~no_nan_loss | ~no_nan_grads:
+            # break
+            if istep > 0:
+                indx_best = np.nanargmin(loss_arr[:istep])
+                best_fit_params = params_arr[indx_best]
+                best_fit_loss = loss_arr[indx_best]
+            else:
+                best_fit_params = np.copy(p)
+                best_fit_loss = 999.99
+        else:
+            params_arr[istep, :] = p
+            loss_arr[istep] = loss
+            opt_state = opt_update(istep, grads, opt_state)
+
+        no_nan_grads_arr[istep] = ~no_nan_grads
+        end = time()
+        if istep % args.print_loss == 0:
+            print(istep, loss, end - start, no_nan_grads)
+        if ~no_nan_grads:
+            break
+
+    argmin_best = np.argmin(loss_arr)
+    best_fit_u_params = params_arr[argmin_best]
+
+    def return_params_from_result(best_fit_u_params):
+        bestfit_u_tuple = array_to_tuple_new_diffstarpop_tpeak(
+            best_fit_u_params, UnboundParams
+        )
+        diffstarpop_params = get_bounded_diffstarpop_params(
+            bestfit_u_tuple.diffstarpop_u_params
+        )
+        return diffstarpop_params
+
+    best_fit_params = return_params_from_result(best_fit_u_params)
+    best_fit_params = tuple_to_array(best_fit_params)
+
+    np.savez(
+        os.path.join(outdir, outname) + ".npz",
+        diffstarpop_params=best_fit_params,
+        diffstarpop_u_params=best_fit_u_params,
+    )


### PR DESCRIPTION
This PR adds satellite-specific quenching for satellite haloes. It does so by adding 4 new parameters for the sigmoid of `frac_quench_sat`, while keeping a separate 4-param sigmoid for the centrals' `frac_quench_cen`. There's a new parameter, `upid` determining if a halo is central or satellite, and `frac_quench` for each halo takes the `frac_quench_cen` or `frac_quench_sat` value depending on `upid`, using `jnp.where`. 

The plots below show results for SMDPL (no-merging). As a result of this change, there's an improvement in the fit quality of `p(sSFR | Mstar)`, for both centrals and satellites, especially for main sequence galaxies. The improvement is not spectacular, but visible if one compares back-and-forth with the model that uses the same frac_quench for both cen and sat. For SMDPL compare to #46. 

One worrisome feature is that the gradient descent gets halted because of a `nan` in the gradients. I suspect the covariance must be hitting some of the boundaries, perhaps because of the `rho_bounds=(-0.3, 0.3)`, which might make the covariance non-positive definite. I want to test what happens if one uses a diagonal covariance.

![smhm_logsm](https://github.com/user-attachments/assets/3836e176-97a0-4ab9-9e3e-80e54d341e26)
![pdf_mstar](https://github.com/user-attachments/assets/f0703c30-b2cb-4da4-867d-043f0d32b53d)
![pdf_ssfr_centrals](https://github.com/user-attachments/assets/1a64e1f7-a66a-434b-9089-1fe96284d1d4)
![pdf_ssfr_satellites](https://github.com/user-attachments/assets/83d69a4f-2ea3-4c6a-8256-6d886c8ed993)
